### PR TITLE
feat(store): add migration functionality

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,10 +11,6 @@ extend-ignore =
     ANN101,
     ANN102
 
-# disable type annotation lints (typing is still enabled) in tests
-per-file-ignores =
-    tests/*:,ANN
-
 # configure flake8-docstrings
 # https://pypi.org/project/flake8-docstrings/
 docstring-convention = pep257

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ Once a `Store` has a migration function in its migrations list, that function **
 
 ### Store.create(directory, schema, primary_key = None, ignore_errors = False, migrations=()) -> Store
 
-| argument        | type              | required | description                                                     |
-| --------------- | ----------------- | -------- | --------------------------------------------------------------- |
-| `directory`     | `str`             | Yes      | Store root directory                                            |
-| `schema`        | `Type[BaseModel]` | Yes      | Document schema                                                 |
-| `primary_key`   | `str`             | No       | Primary key field in `schema`, if applicable                    |
-| `ignore_errors` | `bool`            | No       | Return `None` instead of raising read/parse/write/encode errors |
-| `migrations`    | `List[Migration]` | No       | List of schema migration functions                              |
+| argument        | type                  | required | description                                                     |
+| --------------- | --------------------- | -------- | --------------------------------------------------------------- |
+| `directory`     | `str`                 | Yes      | Store root directory                                            |
+| `schema`        | `Type[BaseModel]`     | Yes      | Document schema                                                 |
+| `primary_key`   | `str`                 | No       | Primary key field in `schema`, if applicable                    |
+| `ignore_errors` | `bool`                | No       | Return `None` instead of raising read/parse/write/encode errors |
+| `migrations`    | `Sequence[Migration]` | No       | Sequence of schema migration functions                          |
 
 ```py
 from junk_drawer import Store
@@ -185,7 +185,7 @@ async def main():
 
 Get an item by key from the store. Returns `None` if no item with that key exists.
 
-### store.get_all_items() -> List[BaseModel]
+### store.get_all_items() -> Sequence[BaseModel]
 
 ```py
 from junk_drawer import Store
@@ -201,7 +201,7 @@ async def main():
 
 Returns a list of all items in the store. If items are not using a `primary_key`, use `get_all_entries` to get items and their associated keys. The order of the items is arbitrary (it depends on [`os.listdir`](https://docs.python.org/3/library/os.html#os.listdir)).
 
-### store.get_all_keys() -> List[str]
+### store.get_all_keys() -> Sequence[str]
 
 ```py
 from junk_drawer import Store
@@ -217,7 +217,7 @@ async def main():
 
 Returns a list of all keys in the store. May return more keys than actual valid documents if there are invalid JSON files in the store directory. The order of the keys is arbitrary (it depends on [`os.listdir`](https://docs.python.org/3/library/os.html#os.listdir)).
 
-### store.get_all_entries() -> List[Tuple[str, BaseModel]]
+### store.get_all_entries() -> Sequence[Tuple[str, BaseModel]]
 
 ```py
 from junk_drawer import Store
@@ -319,5 +319,5 @@ Deletes the backing directory and all files for the store.
 A `Migration` is a function that takes a `Dict[str, Any]` and returns a `Dict[str, Any]`. See [Migrate schemas](#migrate-schemas) section for usage details.
 
 ```py
-Migration = Callable[[Dict[str, Any]], Dict[str, Any]]
+Migration = Callable[[dict], dict]
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ async def main():
 
 Get an item by key from the store. Returns `None` if no item with that key exists.
 
-### store.get_all_items() -> Sequence[BaseModel]
+### store.get_all_items() -> List[BaseModel]
 
 ```py
 from junk_drawer import Store
@@ -201,7 +201,7 @@ async def main():
 
 Returns a list of all items in the store. If items are not using a `primary_key`, use `get_all_entries` to get items and their associated keys. The order of the items is arbitrary (it depends on [`os.listdir`](https://docs.python.org/3/library/os.html#os.listdir)).
 
-### store.get_all_keys() -> Sequence[str]
+### store.get_all_keys() -> List[str]
 
 ```py
 from junk_drawer import Store
@@ -217,7 +217,7 @@ async def main():
 
 Returns a list of all keys in the store. May return more keys than actual valid documents if there are invalid JSON files in the store directory. The order of the keys is arbitrary (it depends on [`os.listdir`](https://docs.python.org/3/library/os.html#os.listdir)).
 
-### store.get_all_entries() -> Sequence[Tuple[str, BaseModel]]
+### store.get_all_entries() -> List[Tuple[str, BaseModel]]
 
 ```py
 from junk_drawer import Store
@@ -319,5 +319,5 @@ Deletes the backing directory and all files for the store.
 A `Migration` is a function that takes a `Dict[str, Any]` and returns a `Dict[str, Any]`. See [Migrate schemas](#migrate-schemas) section for usage details.
 
 ```py
-Migration = Callable[[dict], dict]
+Migration = Callable[[Dict[str, Any]], Dict[str, Any]]
 ```

--- a/junk_drawer/store.py
+++ b/junk_drawer/store.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from logging import getLogger
 from pathlib import PurePath
 from pydantic import BaseModel
-from typing import Generic, List, Optional, Tuple, TypeVar, Type, Union
+from typing import Callable, Generic, Optional, Sequence, Tuple, TypeVar, Type, Union
+
 from .errors import ItemDecodeError, ItemEncodeError, ItemAccessError
 
 from .filesystem import (
@@ -19,7 +20,11 @@ from .filesystem import (
 )
 
 
+SCHEMA_VERSION_KEY = "__schema_version__"
+
 ModelT = TypeVar("ModelT", bound=BaseModel)
+
+Migration = Callable[[dict], dict]
 
 log = getLogger(__name__)
 
@@ -32,35 +37,40 @@ class Store(Generic[ModelT]):
         cls: Type[Store[ModelT]],
         directory: Union[str, PurePath],
         schema: Type[ModelT],
+        *,
         primary_key: Optional[str] = None,
+        migrations: Sequence[Migration] = (),
         ignore_errors: bool = False,
-        filesystem: Optional[AsyncFilesystemLike] = None,
     ) -> Store[ModelT]:
         """Create a Store, waiting for the directory to be set up if necessary."""
         directory = PurePath(directory)
-        filesystem = filesystem if filesystem is not None else AsyncFilesystem()
+        filesystem = AsyncFilesystem()
 
         await filesystem.ensure_dir(directory)
 
         return cls(
             directory=directory,
             schema=schema,
+            migrations=migrations,
             primary_key=primary_key,
-            filesystem=filesystem,
             ignore_errors=ignore_errors,
+            filesystem=filesystem,
         )
 
     def __init__(
         self,
         directory: PurePath,
         schema: Type[ModelT],
+        *,
         primary_key: Optional[str],
-        filesystem: AsyncFilesystemLike,
+        migrations: Sequence[Migration],
         ignore_errors: bool,
+        filesystem: AsyncFilesystemLike,
     ) -> None:
         """Initialize a Store; use Store.create instead."""
         self._directory = directory
         self._schema = schema
+        self._migrations = migrations
         self._primary_key = primary_key
         self._filesystem = filesystem
         self._ignore_errors = ignore_errors
@@ -76,23 +86,23 @@ class Store(Generic[ModelT]):
         read_result = None
         try:
             read_result = await self._filesystem.read_json(
-                key_path, parse_json=self._schema.parse_raw
+                key_path, parse_json=self.parse_json
             )
         except (PathNotFoundError, FileParseError, FileReadError) as error:
             self._maybe_raise_file_error(error)
 
         return read_result
 
-    async def get_all_keys(self) -> List[str]:
+    async def get_all_keys(self) -> Sequence[str]:
         """Get all keys in the store."""
         return await self._filesystem.read_dir(self._directory)
 
-    async def get_all_entries(self) -> List[Tuple[str, ModelT]]:
+    async def get_all_entries(self) -> Sequence[Tuple[str, ModelT]]:
         """Get all keys in the store."""
         try:
             dir_entries = await self._filesystem.read_json_dir(
                 self._directory,
-                parse_json=self._schema.parse_raw,
+                parse_json=self.parse_json,
                 ignore_errors=self._ignore_errors,
             )
         except (PathNotFoundError, FileParseError, FileReadError) as error:
@@ -100,7 +110,7 @@ class Store(Generic[ModelT]):
 
         return [(entry.path.stem, entry.contents) for entry in dir_entries]
 
-    async def get_all_items(self) -> List[ModelT]:
+    async def get_all_items(self) -> Sequence[ModelT]:
         """Get all keys in the store."""
         entries = await self.get_all_entries()
         return [item for key, item in entries]
@@ -170,8 +180,25 @@ class Store(Generic[ModelT]):
         return await self._filesystem.remove_dir(self._directory)
 
     def encode_json(self, item: ModelT) -> str:
-        """Encode a dict into JSON using Pydantic."""
-        return item.json()
+        """Encode a model instance into JSON."""
+        obj = item.dict()
+        obj[SCHEMA_VERSION_KEY] = len(self._migrations)
+
+        # NOTE(mc, 2020-10-25): __json_encoder__ is an undocumented property
+        # of BaseModel, but its usage here is to ensure Pydantic model config
+        # related to serialization is properly used. This functionality is
+        # covered by basic integration tests
+        return item.__config__.json_dumps(obj, default=item.__json_encoder__)
+
+    def parse_json(self, data: str) -> ModelT:
+        """Decode a string into a model instance."""
+        obj = self._schema.__config__.json_loads(data)
+        schema_version = obj.pop(SCHEMA_VERSION_KEY, 0)
+
+        for migrate in self._migrations[schema_version:]:
+            obj = migrate(obj)
+
+        return self._schema.parse_obj(obj)
 
     def _get_item_key(self, item: ModelT, key: Optional[str]) -> str:
         item_key = (

--- a/junk_drawer/store.py
+++ b/junk_drawer/store.py
@@ -4,7 +4,9 @@ from logging import getLogger
 from pathlib import PurePath
 from pydantic import BaseModel
 from typing import (
+    Any,
     Callable,
+    Dict,
     Generic,
     List,
     Optional,
@@ -34,7 +36,7 @@ SCHEMA_VERSION_KEY = "__schema_version__"
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
-Migration = Callable[[dict], dict]
+Migration = Callable[[Dict[str, Any]], Dict[str, Any]]
 
 log = getLogger(__name__)
 

--- a/junk_drawer/store.py
+++ b/junk_drawer/store.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 from logging import getLogger
 from pathlib import PurePath
 from pydantic import BaseModel
-from typing import Callable, Generic, Optional, Sequence, Tuple, TypeVar, Type, Union
+from typing import (
+    Callable,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Type,
+    Union,
+)
 
 from .errors import ItemDecodeError, ItemEncodeError, ItemAccessError
 
@@ -93,11 +103,11 @@ class Store(Generic[ModelT]):
 
         return read_result
 
-    async def get_all_keys(self) -> Sequence[str]:
+    async def get_all_keys(self) -> List[str]:
         """Get all keys in the store."""
         return await self._filesystem.read_dir(self._directory)
 
-    async def get_all_entries(self) -> Sequence[Tuple[str, ModelT]]:
+    async def get_all_entries(self) -> List[Tuple[str, ModelT]]:
         """Get all keys in the store."""
         try:
             dir_entries = await self._filesystem.read_json_dir(
@@ -110,7 +120,7 @@ class Store(Generic[ModelT]):
 
         return [(entry.path.stem, entry.contents) for entry in dir_entries]
 
-    async def get_all_items(self) -> Sequence[ModelT]:
+    async def get_all_items(self) -> List[ModelT]:
         """Get all keys in the store."""
         entries = await self.get_all_entries()
         return [item for key, item in entries]

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,3 @@ warn_return_any = True
 warn_unreachable = True
 strict_equality = True
 show_error_codes = True
-
-[mypy-tests.*]
-disallow_untyped_defs = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Global test configuration."""
 import pytest
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from junk_drawer import Store
 from junk_drawer.filesystem import AsyncFilesystemLike, AsyncFilesystem
 from .helpers import CoolModel
@@ -13,43 +13,43 @@ STORE_PATH_STR = "./store"
 
 
 @pytest.fixture
-def mock_filesystem():
+def mock_filesystem() -> AsyncMock:
     """Create a mock asynchronous filesystem."""
     return AsyncMock(spec=AsyncFilesystemLike)
 
 
 @pytest.fixture
-def filesystem() -> AsyncFilesystemLike:
+def filesystem() -> AsyncFilesystem:
     """Create a real asynchronous filesystem."""
     return AsyncFilesystem()
 
 
 @pytest.fixture
-def mock_parse_json():
+def mock_parse_json() -> MagicMock:
     """Mock parse JSON function."""
     return MagicMock()
 
 
 @pytest.fixture
-def mock_encode_json():
+def mock_encode_json() -> MagicMock:
     """Mock encode JSON function."""
     return MagicMock()
 
 
 @pytest.fixture
-def store_path():
+def store_path() -> PurePath:
     """Store fixture directory path."""
     return PurePath(STORE_PATH_STR)
 
 
 @pytest.fixture
-def real_store_path(tmp_path):
+def real_store_path(tmp_path: Path) -> PurePath:
     """Actual Store directory path."""
     return PurePath(tmp_path) / STORE_PATH_STR
 
 
 @pytest.fixture
-def store(store_path, mock_filesystem) -> Store:
+def store(store_path: PurePath, mock_filesystem: AsyncMock) -> Store[CoolModel]:
     """Create a fresh Store with a mock filesystem."""
     return Store(
         directory=store_path,
@@ -62,7 +62,7 @@ def store(store_path, mock_filesystem) -> Store:
 
 
 @pytest.fixture
-def keyed_store(store_path, mock_filesystem) -> Store:
+def keyed_store(store_path: PurePath, mock_filesystem: AsyncMock) -> Store[CoolModel]:
     """Create a Store with a primary key mock filesystem."""
     return Store(
         directory=store_path,
@@ -75,7 +75,9 @@ def keyed_store(store_path, mock_filesystem) -> Store:
 
 
 @pytest.fixture
-def ignore_errors_store(store_path, mock_filesystem) -> Store:
+def ignore_errors_store(
+    store_path: PurePath, mock_filesystem: AsyncMock
+) -> Store[CoolModel]:
     """Create a Store with errors ignored."""
     return Store(
         directory=store_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,15 @@
 """Global test configuration."""
 import pytest
+from pathlib import PurePath
 from junk_drawer import Store
 from junk_drawer.filesystem import AsyncFilesystemLike, AsyncFilesystem
-from .helpers import CoolModel, STORE_PATH_STR
+from .helpers import CoolModel
 
 # TODO(mc, 2020-09-28): mypy doesn't know about mock.AsyncMock
 from mock import AsyncMock, MagicMock  # type: ignore[attr-defined]
+
+
+STORE_PATH_STR = "./store"
 
 
 @pytest.fixture
@@ -33,35 +37,51 @@ def mock_encode_json():
 
 
 @pytest.fixture
-async def store(mock_filesystem) -> Store:
-    """Create a fresh Store with a mock filesyste."""
-    store = await Store.create(
-        STORE_PATH_STR,
-        schema=CoolModel,
-        filesystem=mock_filesystem,
-    )
-    return store
+def store_path():
+    """Store fixture directory path."""
+    return PurePath(STORE_PATH_STR)
 
 
 @pytest.fixture
-async def keyed_store(mock_filesystem) -> Store:
+def real_store_path(tmp_path):
+    """Actual Store directory path."""
+    return PurePath(tmp_path) / STORE_PATH_STR
+
+
+@pytest.fixture
+def store(store_path, mock_filesystem) -> Store:
+    """Create a fresh Store with a mock filesystem."""
+    return Store(
+        directory=store_path,
+        schema=CoolModel,
+        primary_key=None,
+        migrations=(),
+        ignore_errors=False,
+        filesystem=mock_filesystem,
+    )
+
+
+@pytest.fixture
+def keyed_store(store_path, mock_filesystem) -> Store:
     """Create a Store with a primary key mock filesystem."""
-    store = await Store.create(
-        STORE_PATH_STR,
+    return Store(
+        directory=store_path,
         schema=CoolModel,
         primary_key="foo",
+        migrations=(),
+        ignore_errors=False,
         filesystem=mock_filesystem,
     )
-    return store
 
 
 @pytest.fixture
-async def ignore_errors_store(mock_filesystem) -> Store:
+def ignore_errors_store(store_path, mock_filesystem) -> Store:
     """Create a Store with errors ignored."""
-    store = await Store.create(
-        STORE_PATH_STR,
+    return Store(
+        directory=store_path,
         schema=CoolModel,
+        primary_key=None,
+        migrations=(),
         ignore_errors=True,
         filesystem=mock_filesystem,
     )
-    return store

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,4 @@
 """Test helper classes."""
-from pathlib import PurePath
 from pydantic import BaseModel
 from typing import Union
 
@@ -9,8 +8,3 @@ class CoolModel(BaseModel):
 
     foo: Union[int, str]
     bar: int
-
-
-STORE_PATH_STR = "./store"
-
-store_path = PurePath(STORE_PATH_STR)

--- a/tests/test_async_filesystem_reads.py
+++ b/tests/test_async_filesystem_reads.py
@@ -1,7 +1,11 @@
 """Integration tests for AsyncFilesystem read operations."""
 import pytest
+from mock import MagicMock
 from pathlib import Path, PurePath
+from typing import Any, Dict, List
+
 from junk_drawer.filesystem import (
+    AsyncFilesystem,
     DirectoryEntry as Entry,
     PathNotFoundError,
     FileParseError,
@@ -9,8 +13,12 @@ from junk_drawer.filesystem import (
 
 pytestmark = pytest.mark.asyncio
 
+ParsedObj = Dict[str, Any]
 
-async def test_ensure_dir_noops_when_dir_exists(tmp_path, filesystem):
+
+async def test_ensure_dir_noops_when_dir_exists(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should do nothing with ensure_dir if the directory already exists."""
     tmp_path.mkdir(exist_ok=True)
     dir_name = PurePath(tmp_path)
@@ -19,7 +27,9 @@ async def test_ensure_dir_noops_when_dir_exists(tmp_path, filesystem):
     assert dir_name == result
 
 
-async def test_ensure_dir_creates_dir(tmp_path, filesystem):
+async def test_ensure_dir_creates_dir(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should create a directory with ensure_dir if it doesn't exist."""
     dir_name = PurePath(tmp_path) / "the_limit_does_not_exist"
     result = await filesystem.ensure_dir(dir_name)
@@ -28,14 +38,18 @@ async def test_ensure_dir_creates_dir(tmp_path, filesystem):
     assert Path(dir_name).is_dir()
 
 
-async def test_read_dir_with_empty_dir(tmp_path, filesystem):
+async def test_read_dir_with_empty_dir(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should return an empty list with read_dir on an empty directory."""
     basenames = await filesystem.read_dir(tmp_path)
 
     assert basenames == []
 
 
-async def test_read_dir_with_dir_of_json_files(tmp_path, filesystem):
+async def test_read_dir_with_dir_of_json_files(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should return a list oj JSON basenames with read_dir."""
     (tmp_path / "foo.json").touch()
     (tmp_path / "bar.json").touch()
@@ -45,7 +59,9 @@ async def test_read_dir_with_dir_of_json_files(tmp_path, filesystem):
     assert set(basenames) == set(["foo", "bar", "baz"])
 
 
-async def test_read_dir_ignores_non_json_and_dotfiles(tmp_path, filesystem):
+async def test_read_dir_ignores_non_json_and_dotfiles(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should ignore dotfiles and non-JSON files with read_dir."""
     (tmp_path / "foo.json").touch()
     (tmp_path / ".bar.json").touch()
@@ -55,7 +71,9 @@ async def test_read_dir_ignores_non_json_and_dotfiles(tmp_path, filesystem):
     assert basenames == ["foo"]
 
 
-async def test_file_exists_returns_false_if_no_file(tmp_path, filesystem):
+async def test_file_exists_returns_false_if_no_file(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should return False with file_exists if no JSON files exist."""
     path = PurePath(tmp_path / "foo")
     exists = await filesystem.file_exists(path)
@@ -63,7 +81,9 @@ async def test_file_exists_returns_false_if_no_file(tmp_path, filesystem):
     assert exists is False
 
 
-async def test_file_exists_returns_true_if_file_exists(tmp_path, filesystem):
+async def test_file_exists_returns_true_if_file_exists(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should return True with file_exists if JSON file exists."""
     (tmp_path / "foo.json").touch()
     path = PurePath(tmp_path / "foo")
@@ -72,7 +92,9 @@ async def test_file_exists_returns_true_if_file_exists(tmp_path, filesystem):
     assert exists is True
 
 
-async def test_file_exists_returns_false_if_path_is_directory(tmp_path, filesystem):
+async def test_file_exists_returns_false_if_path_is_directory(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should return False with file_exists if path points to directory."""
     (tmp_path / "foo.json").mkdir()
     path = PurePath(tmp_path / "foo")
@@ -81,17 +103,21 @@ async def test_file_exists_returns_false_if_path_is_directory(tmp_path, filesyst
     assert exists is False
 
 
-async def test_read_json_loads_json_file_to_dict(tmp_path, filesystem):
+async def test_read_json_loads_json_file_to_dict(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should read a file and load the contents into JSON."""
     Path(tmp_path / "foo.json").write_text("""{ "foo": "hello", "bar": 42 }""")
 
     path = PurePath(tmp_path / "foo")
-    result = await filesystem.read_json(path)
+    result: ParsedObj = await filesystem.read_json(path)
 
     assert result == {"foo": "hello", "bar": 42}
 
 
-async def test_read_json_raises_path_does_not_exist_error(tmp_path, filesystem):
+async def test_read_json_raises_path_does_not_exist_error(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should return a FileNotFoundError if file doesn't exist."""
     path = PurePath(tmp_path / "foo")
 
@@ -99,7 +125,9 @@ async def test_read_json_raises_path_does_not_exist_error(tmp_path, filesystem):
         await filesystem.read_json(path)
 
 
-async def test_read_json_raises_parse_error(tmp_path, filesystem):
+async def test_read_json_raises_parse_error(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should raise a FileParseError if file is not valid JSON."""
     Path(tmp_path / "foo.json").write_text("""{ "foo": "hello", }""")
 
@@ -109,14 +137,16 @@ async def test_read_json_raises_parse_error(tmp_path, filesystem):
         await filesystem.read_json(path)
 
 
-async def test_read_json_dir_reads_multiple_files(tmp_path, filesystem):
+async def test_read_json_dir_reads_multiple_files(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should read a all files in a directory."""
     Path(tmp_path / "foo.json").write_text("""{ "foo": "hello", "bar": 0 }""")
     Path(tmp_path / "bar.json").write_text("""{ "foo": "from the", "bar": 1 }""")
     Path(tmp_path / "baz.json").write_text("""{ "foo": "other side", "bar": 2 }""")
 
     path = PurePath(tmp_path)
-    files = await filesystem.read_json_dir(path)
+    files: List[Entry[ParsedObj]] = await filesystem.read_json_dir(path)
 
     assert len(files) == 3
     assert Entry(path=path / "foo", contents={"foo": "hello", "bar": 0}) in files
@@ -124,18 +154,24 @@ async def test_read_json_dir_reads_multiple_files(tmp_path, filesystem):
     assert Entry(path=path / "baz", contents={"foo": "other side", "bar": 2}) in files
 
 
-async def test_read_json_dir_can_ignore_errors(tmp_path, filesystem):
+async def test_read_json_dir_can_ignore_errors(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should allow reading all directory files while ignoring any errors."""
     Path(tmp_path / "foo.json").write_text("""{ "foo": "hello", "bar": 0 }""")
     Path(tmp_path / "bar.json").write_text("""{ "foo": "from the",}""")
 
     path = PurePath(tmp_path)
-    files = await filesystem.read_json_dir(path, ignore_errors=True)
+    files: List[Entry[ParsedObj]] = await filesystem.read_json_dir(
+        path, ignore_errors=True
+    )
 
     assert files == [Entry(path=path / "foo", contents={"foo": "hello", "bar": 0})]
 
 
-async def test_read_json_with_custom_parser(tmp_path, mock_parse_json, filesystem):
+async def test_read_json_with_custom_parser(
+    tmp_path: Path, mock_parse_json: MagicMock, filesystem: AsyncFilesystem
+) -> None:
     """It should read a file and parse into JSON using custom parser."""
     Path(tmp_path / "foo.json").write_text("""{ "this": "is crazy" }""")
 
@@ -148,8 +184,8 @@ async def test_read_json_with_custom_parser(tmp_path, mock_parse_json, filesyste
 
 
 async def test_read_json_when_custom_parser_raises(
-    tmp_path, mock_parse_json, filesystem
-):
+    tmp_path: Path, mock_parse_json: MagicMock, filesystem: AsyncFilesystem
+) -> None:
     """It should raise a FileParseError if the custom parser raises."""
     Path(tmp_path / "foo.json").write_text("""{ "foo": "hello", "bar": 42 }""")
 
@@ -161,7 +197,9 @@ async def test_read_json_when_custom_parser_raises(
         await filesystem.read_json(path, parse_json=mock_parse_json)
 
 
-async def test_read_json_dir_with_custom_parser(tmp_path, mock_parse_json, filesystem):
+async def test_read_json_dir_with_custom_parser(
+    tmp_path: Path, mock_parse_json: MagicMock, filesystem: AsyncFilesystem
+) -> None:
     """It should read a all files in a directory."""
     Path(tmp_path / "foo.json").write_text("""{ "foo": "hello", "bar": 0 }""")
     Path(tmp_path / "bar.json").write_text("""{ "foo": "from the", "bar": 1 }""")

--- a/tests/test_async_filesystem_writes.py
+++ b/tests/test_async_filesystem_writes.py
@@ -1,11 +1,13 @@
 """Integration tests for AsyncFilesystem read operations."""
 import pytest
-from junk_drawer.filesystem import PathNotFoundError, FileEncodeError
+from mock import MagicMock
+from pathlib import Path
+from junk_drawer.filesystem import AsyncFilesystem, PathNotFoundError, FileEncodeError
 
 pytestmark = pytest.mark.asyncio
 
 
-async def test_remove_deletes_file(tmp_path, filesystem):
+async def test_remove_deletes_file(tmp_path: Path, filesystem: AsyncFilesystem) -> None:
     """It should delete a given file."""
     path = tmp_path / "foo"
     path.with_suffix(".json").touch()
@@ -15,7 +17,9 @@ async def test_remove_deletes_file(tmp_path, filesystem):
     assert path.exists() is False
 
 
-async def test_remove_raises_if_no_file(tmp_path, filesystem):
+async def test_remove_raises_if_no_file(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should raise a PathNotFoundError error if file to remove isn't found."""
     path = tmp_path / "foo"
 
@@ -23,7 +27,9 @@ async def test_remove_raises_if_no_file(tmp_path, filesystem):
         await filesystem.remove(path)
 
 
-async def test_remove_dir_deletes_tree(tmp_path, filesystem):
+async def test_remove_dir_deletes_tree(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should delete a directory and all files in it."""
     (tmp_path / "foo.json").touch()
     (tmp_path / "bar.json").touch()
@@ -34,7 +40,9 @@ async def test_remove_dir_deletes_tree(tmp_path, filesystem):
     assert tmp_path.exists() is False
 
 
-async def test_write_json_enocdes_and_writes_obj(tmp_path, filesystem):
+async def test_write_json_enocdes_and_writes_obj(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should encode and write a JSON object to a file."""
     path = tmp_path / "foo"
     await filesystem.write_json(path, {"foo": "hello", "bar": 0})
@@ -42,7 +50,9 @@ async def test_write_json_enocdes_and_writes_obj(tmp_path, filesystem):
     assert path.with_suffix(".json").read_text() == """{"foo": "hello", "bar": 0}"""
 
 
-async def test_write_json_raises_encode_error(tmp_path, filesystem):
+async def test_write_json_raises_encode_error(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
     """It should raise a FileEncodeError if object cannot be encoded to JSON."""
     path = tmp_path / "foo"
 
@@ -50,7 +60,9 @@ async def test_write_json_raises_encode_error(tmp_path, filesystem):
         await filesystem.write_json(path, {"nope": ...})
 
 
-async def test_write_json_with_custom_encoder(tmp_path, mock_encode_json, filesystem):
+async def test_write_json_with_custom_encoder(
+    tmp_path: Path, mock_encode_json: MagicMock, filesystem: AsyncFilesystem
+) -> None:
     """It should encode and write a file using a custom encoder."""
     path = tmp_path / "foo"
     obj = {"foo": "hello", "bar": 0}
@@ -63,8 +75,8 @@ async def test_write_json_with_custom_encoder(tmp_path, mock_encode_json, filesy
 
 
 async def test_write_json_when_custom_encoder_raises(
-    tmp_path, mock_encode_json, filesystem
-):
+    tmp_path: Path, mock_encode_json: MagicMock, filesystem: AsyncFilesystem
+) -> None:
     """It should raise a FileEncodeError if the custom encoder raises."""
     path = tmp_path / "foo"
     obj = {"foo": "hello", "bar": 0}

--- a/tests/test_junk_drawer.py
+++ b/tests/test_junk_drawer.py
@@ -1,5 +1,6 @@
 """Entrypoint and end-to-end tests for junk_drawer."""
 import pytest
+from pathlib import PurePath
 from pydantic import BaseModel
 from junk_drawer import Store
 from typing import Optional
@@ -21,7 +22,7 @@ class OldModel(BaseModel):
     foo: str
 
 
-async def test_store_write_and_read(real_store_path):
+async def test_store_write_and_read(real_store_path: PurePath) -> None:
     """A store should be able to write and read a file."""
     store = await Store.create(real_store_path, schema=CoolModel)
     item = CoolModel(foo="hello", bar="world")
@@ -35,7 +36,7 @@ async def test_store_write_and_read(real_store_path):
     assert result == CoolModel(foo="hello", bar="world")
 
 
-async def test_store_write_and_read_dir(real_store_path):
+async def test_store_write_and_read_dir(real_store_path: PurePath) -> None:
     """A store should be able to write and read the whole store."""
     store = await Store.create(real_store_path, schema=CoolModel)
 
@@ -50,7 +51,7 @@ async def test_store_write_and_read_dir(real_store_path):
     assert ("bar", CoolModel(foo="oh", bar="hai")) in result
 
 
-async def test_store_write_and_ensure(real_store_path):
+async def test_store_write_and_ensure(real_store_path: PurePath) -> None:
     """A store should be able to write and read a file."""
     store = await Store.create(real_store_path, schema=CoolModel)
     default_item = CoolModel(foo="default", bar="value")
@@ -65,7 +66,7 @@ async def test_store_write_and_ensure(real_store_path):
     assert result == item
 
 
-async def test_keyed_store_write_and_read(real_store_path):
+async def test_keyed_store_write_and_read(real_store_path: PurePath) -> None:
     """A store should be able to write and read a file."""
     store = await Store.create(real_store_path, schema=CoolModel, primary_key="foo")
     item = CoolModel(foo="hello", bar="world")
@@ -79,7 +80,7 @@ async def test_keyed_store_write_and_read(real_store_path):
     assert result == CoolModel(foo="hello", bar="world")
 
 
-async def test_keyed_store_write_and_read_dir(real_store_path):
+async def test_keyed_store_write_and_read_dir(real_store_path: PurePath) -> None:
     """A store should be able to write and read the whole store."""
     store = await Store.create(real_store_path, schema=CoolModel, primary_key="foo")
 
@@ -94,7 +95,7 @@ async def test_keyed_store_write_and_read_dir(real_store_path):
     assert ("oh", CoolModel(foo="oh", bar="hai")) in result
 
 
-async def test_keyed_store_write_and_ensure(real_store_path):
+async def test_keyed_store_write_and_ensure(real_store_path: PurePath) -> None:
     """A store should be able to write and read a file."""
     store = await Store.create(real_store_path, schema=CoolModel, primary_key="foo")
     default_item = CoolModel(foo="some-key", bar="hello world")
@@ -109,12 +110,14 @@ async def test_keyed_store_write_and_ensure(real_store_path):
     assert result == item
 
 
-async def test_store_write_and_read_with_migrations(real_store_path):
+async def test_store_write_and_read_with_migrations(real_store_path: PurePath) -> None:
     """A store should be able to write and read a file."""
     old_store = await Store.create(real_store_path, schema=OldModel)
 
+    item_key = "some-key"
     item = OldModel(foo="hello")
-    item_key = await old_store.put(item, "some-key")
+
+    await old_store.put(item, item_key)
 
     new_store = await Store.create(
         real_store_path,

--- a/tests/test_junk_drawer.py
+++ b/tests/test_junk_drawer.py
@@ -1,8 +1,8 @@
-"""Entrypoint and e2e tests for junk_drawer."""
+"""Entrypoint and end-to-end tests for junk_drawer."""
 import pytest
 from pydantic import BaseModel
 from junk_drawer import Store
-
+from typing import Optional
 
 pytestmark = pytest.mark.asyncio
 
@@ -12,11 +12,18 @@ class CoolModel(BaseModel):
 
     foo: str
     bar: str
+    baz: Optional[int] = None
 
 
-async def test_store_write_and_read(tmp_path):
+class OldModel(BaseModel):
+    """A model at an "older" schema version."""
+
+    foo: str
+
+
+async def test_store_write_and_read(real_store_path):
     """A store should be able to write and read a file."""
-    store = await Store.create(tmp_path, schema=CoolModel)
+    store = await Store.create(real_store_path, schema=CoolModel)
     item = CoolModel(foo="hello", bar="world")
 
     key = await store.put(item, "foo")
@@ -28,9 +35,9 @@ async def test_store_write_and_read(tmp_path):
     assert result == CoolModel(foo="hello", bar="world")
 
 
-async def test_store_write_and_read_dir(tmp_path):
+async def test_store_write_and_read_dir(real_store_path):
     """A store should be able to write and read the whole store."""
-    store = await Store.create(tmp_path, schema=CoolModel)
+    store = await Store.create(real_store_path, schema=CoolModel)
 
     # TODO(mc, 2020-10-03): replace with store.add
     await store.put(CoolModel(foo="hello", bar="world"), "foo")
@@ -43,9 +50,9 @@ async def test_store_write_and_read_dir(tmp_path):
     assert ("bar", CoolModel(foo="oh", bar="hai")) in result
 
 
-async def test_store_write_and_ensure(tmp_path):
+async def test_store_write_and_ensure(real_store_path):
     """A store should be able to write and read a file."""
-    store = await Store.create(tmp_path, schema=CoolModel)
+    store = await Store.create(real_store_path, schema=CoolModel)
     default_item = CoolModel(foo="default", bar="value")
     item = CoolModel(foo="hello", bar="world")
 
@@ -58,9 +65,9 @@ async def test_store_write_and_ensure(tmp_path):
     assert result == item
 
 
-async def test_keyed_store_write_and_read(tmp_path):
+async def test_keyed_store_write_and_read(real_store_path):
     """A store should be able to write and read a file."""
-    store = await Store.create(tmp_path, schema=CoolModel, primary_key="foo")
+    store = await Store.create(real_store_path, schema=CoolModel, primary_key="foo")
     item = CoolModel(foo="hello", bar="world")
 
     key = await store.put(item)
@@ -72,9 +79,9 @@ async def test_keyed_store_write_and_read(tmp_path):
     assert result == CoolModel(foo="hello", bar="world")
 
 
-async def test_keyed_store_write_and_read_dir(tmp_path):
+async def test_keyed_store_write_and_read_dir(real_store_path):
     """A store should be able to write and read the whole store."""
-    store = await Store.create(tmp_path, schema=CoolModel, primary_key="foo")
+    store = await Store.create(real_store_path, schema=CoolModel, primary_key="foo")
 
     # TODO(mc, 2020-10-03): replace with store.add
     await store.put(CoolModel(foo="hello", bar="world"))
@@ -87,9 +94,9 @@ async def test_keyed_store_write_and_read_dir(tmp_path):
     assert ("oh", CoolModel(foo="oh", bar="hai")) in result
 
 
-async def test_keyed_store_write_and_ensure(tmp_path):
+async def test_keyed_store_write_and_ensure(real_store_path):
     """A store should be able to write and read a file."""
-    store = await Store.create(tmp_path, schema=CoolModel, primary_key="foo")
+    store = await Store.create(real_store_path, schema=CoolModel, primary_key="foo")
     default_item = CoolModel(foo="some-key", bar="hello world")
     item = CoolModel(foo="some-key", bar="oh hai")
 
@@ -100,3 +107,24 @@ async def test_keyed_store_write_and_ensure(tmp_path):
     result = await store.ensure(default_item)
 
     assert result == item
+
+
+async def test_store_write_and_read_with_migrations(real_store_path):
+    """A store should be able to write and read a file."""
+    old_store = await Store.create(real_store_path, schema=OldModel)
+
+    item = OldModel(foo="hello")
+    item_key = await old_store.put(item, "some-key")
+
+    new_store = await Store.create(
+        real_store_path,
+        schema=CoolModel,
+        migrations=(
+            lambda obj: {"foo": obj["foo"], "bar": "world"},
+            lambda obj: {"foo": obj["foo"], "bar": obj["bar"], "baz": 0},
+        ),
+    )
+
+    result = await new_store.get(item_key)
+
+    assert result == CoolModel(foo="hello", bar="world", baz=0)

--- a/tests/test_store_json_and_migrations.py
+++ b/tests/test_store_json_and_migrations.py
@@ -1,0 +1,106 @@
+"""Tests for the store's JSON and migration handling."""
+import pytest
+from pydantic import BaseModel
+from junk_drawer import Store
+from .helpers import CoolModel
+
+
+class StrictModel(CoolModel, BaseModel):
+    """Pydantic model that disallows extra fields."""
+
+    class Config:
+        """Model config to disallow extra fields."""
+
+        extra = "forbid"
+
+
+@pytest.fixture
+def strict_store(store_path, mock_filesystem) -> Store:
+    """Create a Store with a strict model."""
+    return Store(
+        directory=store_path,
+        schema=StrictModel,
+        primary_key=None,
+        migrations=(),
+        ignore_errors=False,
+        filesystem=mock_filesystem,
+    )
+
+
+@pytest.fixture
+def migrations_store(store_path, mock_filesystem) -> Store:
+    """Create a Store with migrations."""
+
+    def migration_0(obj):
+        """Add "foo" key."""
+        obj["foo"] = "hello"
+        return obj
+
+    def migration_1(obj):
+        """Add "bar" key."""
+        obj["bar"] = 0
+        return obj
+
+    return Store(
+        directory=store_path,
+        schema=CoolModel,
+        primary_key=None,
+        migrations=(migration_0, migration_1),
+        ignore_errors=False,
+        filesystem=mock_filesystem,
+    )
+
+
+def test_encode_json(store):
+    """It should encode a Pydantic model to a JSON string."""
+    model = CoolModel(foo="hello", bar=42)
+    result = store.encode_json(model)
+
+    assert result == '{"foo": "hello", "bar": 42, "__schema_version__": 0}'
+
+
+def test_encode_json_with_migrations(migrations_store):
+    """It should write the schema version based on migrations."""
+    model = CoolModel(foo="hello", bar=42)
+    result = migrations_store.encode_json(model)
+
+    assert result == '{"foo": "hello", "bar": 42, "__schema_version__": 2}'
+
+
+def test_parse_json(store):
+    """It should parse a JSON string into a Pydantic model."""
+    data = '{"foo": "hello", "bar": 42, "__schema_version__": 0}'
+    result = store.parse_json(data)
+
+    assert result == CoolModel(foo="hello", bar=42)
+
+
+def test_parse_json_strict(strict_store):
+    """It should parse a JSON string into a model with extra: forbid."""
+    data = '{"foo": "hello", "bar": 42, "__schema_version__": 0}'
+    result = strict_store.parse_json(data)
+
+    assert result == StrictModel(foo="hello", bar=42)
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        ("{}", CoolModel(foo="hello", bar=0)),
+        ('{"__schema_version__": 0}', CoolModel(foo="hello", bar=0)),
+        ('{"__schema_version__": 1, "foo": "hey"}', CoolModel(foo="hey", bar=0)),
+        (
+            '{"__schema_version__": 2, "foo": "hey", "bar": 1}',
+            CoolModel(foo="hey", bar=1),
+        ),
+        (
+            '{"__schema_version__": 3, "foo": "hey", "bar": 1, "future": "value"}',
+            CoolModel(foo="hey", bar=1),
+        ),
+    ],
+)
+def test_parse_json_with_migrations(migrations_store, data, expected):
+    """It should parse a JSON string and apply migrations from v0."""
+    result = migrations_store.parse_json(data)
+
+    assert result == expected

--- a/tests/test_store_reads.py
+++ b/tests/test_store_reads.py
@@ -1,6 +1,9 @@
 """Store tests for junk_drawer."""
 import pytest
+from pathlib import PurePath
+from mock import AsyncMock  # type: ignore[attr-defined]
 
+from junk_drawer import Store
 from junk_drawer.errors import ItemDecodeError, ItemAccessError
 from junk_drawer.filesystem import (
     DirectoryEntry as DirEntry,
@@ -8,13 +11,16 @@ from junk_drawer.filesystem import (
     FileReadError,
     FileParseError,
 )
+
 from .helpers import CoolModel
 
 
 pytestmark = pytest.mark.asyncio
 
 
-async def test_store_exists_with_nonexistent_key(store, store_path, mock_filesystem):
+async def test_store_exists_with_nonexistent_key(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """It should return False from store.exists if file doesn't exist."""
     mock_filesystem.file_exists.return_value = False
     exists = await store.exists("foo")
@@ -23,7 +29,9 @@ async def test_store_exists_with_nonexistent_key(store, store_path, mock_filesys
     mock_filesystem.file_exists.assert_called_with(store_path / "foo")
 
 
-async def test_store_exists_with_existing_key(store, mock_filesystem):
+async def test_store_exists_with_existing_key(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """It should return True from store.exists if file exists."""
     mock_filesystem.file_exists.return_value = True
     exists = await store.exists("foo")
@@ -31,7 +39,9 @@ async def test_store_exists_with_existing_key(store, mock_filesystem):
     assert exists is True
 
 
-async def test_store_get_with_nonexistent_key(store, store_path, mock_filesystem):
+async def test_store_get_with_nonexistent_key(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """It should return None from store.get if file doesn't exist."""
     mock_filesystem.read_json.side_effect = PathNotFoundError()
     item = await store.get("foo")
@@ -42,7 +52,9 @@ async def test_store_get_with_nonexistent_key(store, store_path, mock_filesystem
     )
 
 
-async def test_store_get_returns_read_result(store, store_path, mock_filesystem):
+async def test_store_get_returns_read_result(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """It should return a model from store.get if file exists."""
     result = CoolModel(foo="bar", bar=42)
     mock_filesystem.read_json.return_value = result
@@ -54,7 +66,9 @@ async def test_store_get_returns_read_result(store, store_path, mock_filesystem)
     )
 
 
-async def test_store_get_all_keys_reads_dir(store, store_path, mock_filesystem):
+async def test_store_get_all_keys_reads_dir(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """It should read the directory and return all JSON files as keys."""
     mock_filesystem.read_dir.return_value = ["foo", "bar", "baz"]
     keys = await store.get_all_keys()
@@ -63,7 +77,9 @@ async def test_store_get_all_keys_reads_dir(store, store_path, mock_filesystem):
     mock_filesystem.read_dir.assert_called_with(store_path)
 
 
-async def test_store_get_all_entries_reads_dir(store, store_path, mock_filesystem):
+async def test_store_get_all_entries_reads_dir(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """It should reads for all files in the directory to get all entries."""
     mock_filesystem.read_json_dir.return_value = [
         DirEntry(path=store_path / "foo", contents=CoolModel(foo="hello", bar=0)),
@@ -80,7 +96,9 @@ async def test_store_get_all_entries_reads_dir(store, store_path, mock_filesyste
     )
 
 
-async def test_store_get_all_items_reads_dir(store, store_path, mock_filesystem):
+async def test_store_get_all_items_reads_dir(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """It should read all files in the directory to get all items."""
     mock_filesystem.read_json_dir.return_value = [
         DirEntry(path=store_path / "foo", contents=CoolModel(foo="hello", bar=0)),
@@ -97,7 +115,9 @@ async def test_store_get_all_items_reads_dir(store, store_path, mock_filesystem)
     )
 
 
-async def test_store_get_raises_invalid_json(store, mock_filesystem):
+async def test_store_get_raises_invalid_json(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """It should raise a validation error if the data fails to parse."""
     mock_filesystem.read_json.side_effect = FileParseError("oh no")
     mock_filesystem.read_json_dir.side_effect = FileParseError("oh no")
@@ -109,7 +129,9 @@ async def test_store_get_raises_invalid_json(store, mock_filesystem):
         await store.get_all_items()
 
 
-async def test_store_get_raises_read_error(store, mock_filesystem):
+async def test_store_get_raises_read_error(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """It should raise an access error if the data fails to read."""
     mock_filesystem.read_json.side_effect = FileReadError("oh no")
     mock_filesystem.read_json_dir.side_effect = FileReadError("oh no")
@@ -122,8 +144,10 @@ async def test_store_get_raises_read_error(store, mock_filesystem):
 
 
 async def test_silenced_validation_error(
-    ignore_errors_store, store_path, mock_filesystem
-):
+    ignore_errors_store: Store[CoolModel],
+    store_path: PurePath,
+    mock_filesystem: AsyncMock,
+) -> None:
     """It should return None in case of a validation error if set to not raise."""
     mock_filesystem.read_json.side_effect = FileParseError("oh no")
     mock_filesystem.read_json_dir.return_value = [

--- a/tests/test_store_reads.py
+++ b/tests/test_store_reads.py
@@ -1,6 +1,6 @@
 """Store tests for junk_drawer."""
 import pytest
-from junk_drawer import Store
+
 from junk_drawer.errors import ItemDecodeError, ItemAccessError
 from junk_drawer.filesystem import (
     DirectoryEntry as DirEntry,
@@ -8,19 +8,13 @@ from junk_drawer.filesystem import (
     FileReadError,
     FileParseError,
 )
-from .helpers import CoolModel, store_path
+from .helpers import CoolModel
 
 
 pytestmark = pytest.mark.asyncio
 
 
-async def test_store_create(store, mock_filesystem):
-    """It should be able to create a Store backed by a directory."""
-    assert type(store) == Store
-    mock_filesystem.ensure_dir.assert_called_with(store_path)
-
-
-async def test_store_exists_with_nonexistent_key(store, mock_filesystem):
+async def test_store_exists_with_nonexistent_key(store, store_path, mock_filesystem):
     """It should return False from store.exists if file doesn't exist."""
     mock_filesystem.file_exists.return_value = False
     exists = await store.exists("foo")
@@ -37,18 +31,18 @@ async def test_store_exists_with_existing_key(store, mock_filesystem):
     assert exists is True
 
 
-async def test_store_get_with_nonexistent_key(store, mock_filesystem):
+async def test_store_get_with_nonexistent_key(store, store_path, mock_filesystem):
     """It should return None from store.get if file doesn't exist."""
     mock_filesystem.read_json.side_effect = PathNotFoundError()
     item = await store.get("foo")
 
     assert item is None
     mock_filesystem.read_json.assert_called_with(
-        store_path / "foo", parse_json=CoolModel.parse_raw
+        store_path / "foo", parse_json=store.parse_json
     )
 
 
-async def test_store_get_returns_read_result(store, mock_filesystem):
+async def test_store_get_returns_read_result(store, store_path, mock_filesystem):
     """It should return a model from store.get if file exists."""
     result = CoolModel(foo="bar", bar=42)
     mock_filesystem.read_json.return_value = result
@@ -56,11 +50,11 @@ async def test_store_get_returns_read_result(store, mock_filesystem):
 
     assert item == result
     mock_filesystem.read_json.assert_called_with(
-        store_path / "foo", parse_json=CoolModel.parse_raw
+        store_path / "foo", parse_json=store.parse_json
     )
 
 
-async def test_store_reads_dir_for_get_all_keys(store, mock_filesystem):
+async def test_store_get_all_keys_reads_dir(store, store_path, mock_filesystem):
     """It should read the directory and return all JSON files as keys."""
     mock_filesystem.read_dir.return_value = ["foo", "bar", "baz"]
     keys = await store.get_all_keys()
@@ -69,7 +63,7 @@ async def test_store_reads_dir_for_get_all_keys(store, mock_filesystem):
     mock_filesystem.read_dir.assert_called_with(store_path)
 
 
-async def test_store_reads_whole_dir_for_get_all_entries(store, mock_filesystem):
+async def test_store_get_all_entries_reads_dir(store, store_path, mock_filesystem):
     """It should reads for all files in the directory to get all entries."""
     mock_filesystem.read_json_dir.return_value = [
         DirEntry(path=store_path / "foo", contents=CoolModel(foo="hello", bar=0)),
@@ -82,11 +76,11 @@ async def test_store_reads_whole_dir_for_get_all_entries(store, mock_filesystem)
     assert items[1] == ("bar", CoolModel(foo="from the", bar=1))
     assert items[2] == ("baz", CoolModel(foo="other side", bar=2))
     mock_filesystem.read_json_dir.assert_called_with(
-        store_path, parse_json=CoolModel.parse_raw, ignore_errors=False
+        store_path, parse_json=store.parse_json, ignore_errors=False
     )
 
 
-async def test_store_reads_whole_dir_for_get_all_items(store, mock_filesystem):
+async def test_store_get_all_items_reads_dir(store, store_path, mock_filesystem):
     """It should read all files in the directory to get all items."""
     mock_filesystem.read_json_dir.return_value = [
         DirEntry(path=store_path / "foo", contents=CoolModel(foo="hello", bar=0)),
@@ -99,7 +93,7 @@ async def test_store_reads_whole_dir_for_get_all_items(store, mock_filesystem):
     assert items[1] == CoolModel(foo="from the", bar=1)
     assert items[2] == CoolModel(foo="other side", bar=2)
     mock_filesystem.read_json_dir.assert_called_with(
-        store_path, parse_json=CoolModel.parse_raw, ignore_errors=False
+        store_path, parse_json=store.parse_json, ignore_errors=False
     )
 
 
@@ -127,7 +121,9 @@ async def test_store_get_raises_read_error(store, mock_filesystem):
         await store.get_all_items()
 
 
-async def test_validation_error_may_be_silenced(ignore_errors_store, mock_filesystem):
+async def test_silenced_validation_error(
+    ignore_errors_store, store_path, mock_filesystem
+):
     """It should return None in case of a validation error if set to not raise."""
     mock_filesystem.read_json.side_effect = FileParseError("oh no")
     mock_filesystem.read_json_dir.return_value = [
@@ -139,5 +135,5 @@ async def test_validation_error_may_be_silenced(ignore_errors_store, mock_filesy
     assert item is None
     assert all_items == [CoolModel(foo="hello", bar=0)]
     mock_filesystem.read_json_dir.assert_called_with(
-        store_path, parse_json=CoolModel.parse_raw, ignore_errors=True
+        store_path, parse_json=ignore_errors_store.parse_json, ignore_errors=True
     )

--- a/tests/test_store_writes.py
+++ b/tests/test_store_writes.py
@@ -1,5 +1,8 @@
 """Store tests for junk_drawer."""
 import pytest
+from mock import AsyncMock  # type: ignore[attr-defined]
+from pathlib import PurePath
+
 from junk_drawer import Store
 from junk_drawer.errors import ItemAccessError, ItemEncodeError
 from junk_drawer.filesystem import (
@@ -14,13 +17,17 @@ from .helpers import CoolModel
 pytestmark = pytest.mark.asyncio
 
 
-async def test_delete_store(store, store_path, mock_filesystem):
+async def test_delete_store(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """store.delete_store should remove the directory."""
     await store.delete_store()
     mock_filesystem.remove_dir.assert_called_with(store_path)
 
 
-async def test_delete_item(store, store_path, mock_filesystem):
+async def test_delete_item(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """store.delete should remove a file."""
     key = "delete-me"
     removed = await store.delete(key)
@@ -29,7 +36,9 @@ async def test_delete_item(store, store_path, mock_filesystem):
     mock_filesystem.remove.assert_called_with(store_path / key)
 
 
-async def test_delete_item_nonexistent_key(store, mock_filesystem):
+async def test_delete_item_nonexistent_key(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.delete should return None if path does not exist."""
     key = "delete-me"
     mock_filesystem.remove.side_effect = PathNotFoundError("oh no")
@@ -38,7 +47,9 @@ async def test_delete_item_nonexistent_key(store, mock_filesystem):
     assert removed is None
 
 
-async def test_delete_item_with_access_error(store, mock_filesystem):
+async def test_delete_item_with_access_error(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.delete should raise an ItemAccessError if file can't be removed."""
     key = "delete-me"
     mock_filesystem.remove.side_effect = RemoveFileError("oh no")
@@ -47,7 +58,9 @@ async def test_delete_item_with_access_error(store, mock_filesystem):
         await store.delete(key)
 
 
-async def test_store_put(store, store_path, mock_filesystem):
+async def test_store_put(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """store.put should call filesystem.write_json."""
     key = "cool-key"
     item = CoolModel(foo="hello", bar=0)
@@ -61,7 +74,9 @@ async def test_store_put(store, store_path, mock_filesystem):
     )
 
 
-async def test_store_put_raises_access_error(store, mock_filesystem):
+async def test_store_put_raises_access_error(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.put should raise an ItemAccessError if file cannot be written."""
     key = "cool-key"
     mock_filesystem.write_json.side_effect = FileWriteError("oh no")
@@ -70,7 +85,9 @@ async def test_store_put_raises_access_error(store, mock_filesystem):
         await store.put(CoolModel(foo="hello", bar=0), key)
 
 
-async def test_store_put_raises_encode_error(store, mock_filesystem):
+async def test_store_put_raises_encode_error(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.put should raise an ItemAccessError if file cannot be written."""
     key = "cool-key"
     mock_filesystem.write_json.side_effect = FileEncodeError("oh no")
@@ -79,7 +96,9 @@ async def test_store_put_raises_encode_error(store, mock_filesystem):
         await store.put(CoolModel(foo="hello", bar=0), key)
 
 
-async def test_store_put_with_primary_key(keyed_store, store_path, mock_filesystem):
+async def test_store_put_with_primary_key(
+    keyed_store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """store.put should pull primary key from the model if available."""
     item = CoolModel(foo="hello", bar=0)
     put_key = await keyed_store.put(item)
@@ -92,7 +111,9 @@ async def test_store_put_with_primary_key(keyed_store, store_path, mock_filesyst
     )
 
 
-async def test_store_put_with_non_string_primary_key(keyed_store, mock_filesystem):
+async def test_store_put_with_non_string_primary_key(
+    keyed_store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.put should pull primary key from the model if available."""
     item = CoolModel(foo=101, bar=0)
     put_key = await keyed_store.put(item)
@@ -101,7 +122,9 @@ async def test_store_put_with_non_string_primary_key(keyed_store, mock_filesyste
     assert put_key == "101"
 
 
-async def test_store_put_missing_key_asserts(store, mock_filesystem):
+async def test_store_put_missing_key_asserts(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.put should assert if used without an explicit key."""
     item = CoolModel(foo="hello", bar=0)
 
@@ -109,7 +132,9 @@ async def test_store_put_missing_key_asserts(store, mock_filesystem):
         await store.put(item)
 
 
-async def test_store_put_bad_primary_key_asserts(store_path, mock_filesystem):
+async def test_store_put_bad_primary_key_asserts(
+    store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """store.put should assert if used with a primary_key that isn't in the model."""
     store = Store(
         directory=store_path,
@@ -126,8 +151,8 @@ async def test_store_put_bad_primary_key_asserts(store_path, mock_filesystem):
 
 
 async def test_store_put_returns_none_if_ignoring_errors(
-    ignore_errors_store, mock_filesystem
-):
+    ignore_errors_store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.put should return None if item cannot be encoded / written."""
     key = "cool-key"
     mock_filesystem.write_json.side_effect = FileWriteError("oh no")
@@ -141,7 +166,9 @@ async def test_store_put_returns_none_if_ignoring_errors(
     assert result is None
 
 
-async def test_store_ensure(store, mock_filesystem):
+async def test_store_ensure(
+    store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.ensure should return item if it exists already."""
     default_item = CoolModel(foo="foo", bar=0)
     existing_item = CoolModel(foo="bar", bar=1)
@@ -152,7 +179,9 @@ async def test_store_ensure(store, mock_filesystem):
     assert item == existing_item
 
 
-async def test_store_ensure_writes_default(store, store_path, mock_filesystem):
+async def test_store_ensure_writes_default(
+    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+) -> None:
     """store.ensure should write default item and return it."""
     default_item = CoolModel(foo="foo", bar=0)
     mock_filesystem.read_json.side_effect = PathNotFoundError()
@@ -167,7 +196,9 @@ async def test_store_ensure_writes_default(store, store_path, mock_filesystem):
     )
 
 
-async def test_store_ensure_with_primary_key(keyed_store, mock_filesystem):
+async def test_store_ensure_with_primary_key(
+    keyed_store: Store[CoolModel], mock_filesystem: AsyncMock
+) -> None:
     """store.ensure should return item if it exists already."""
     default_item = CoolModel(foo="foo", bar=0)
     existing_item = CoolModel(foo="bar", bar=1)


### PR DESCRIPTION
## overview

This PR adds simple migration-on-read functionality to the Store. Closes #6.

Since all store writes are full model writes, and in the interest of keeping backwards compatibility during software downgrades a little more likely to work, migrations are not written back to the filesystem by the migration system. If the user ends up updating an item, it will always be at the latest schema version.

## change log

- feat(store): add migration functionality

### cleanup

- refactor(store): remove test-specific code from the `create` factory method and enforce keyword usage for optional parameters

## review requests

- [ ] Does the implementation described below make sense?
- [ ] Was it implemented correctly?
- [ ] Does it hit our migration acceptance criteria (see ticket)?
- [ ] How do the tests look?

This PR adds integration and end-to-end tests for the migration functionality. This functionality is built all in the JSON parse / encode phases:

- Parse
    1. Parse JSON into dict
    2. Pull schema version out of dict
    3. Apply necessary migrations
    4. Pass migrated dict to Pydantic for validation / item construction
- Encode
    1. Dump Pydantic model to dict
    2. Add schema version to dict based on number of entries in the migrations list
    3. Dump dict to JSON string
