### PR TITLE
ci: add release and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           name: junk-drawer
           path: dist
-      - if: startsWith(github.ref, "refs/tags/v")
+      - if: startsWith(github.ref, 'refs/tags/v')
         name: Deploy to PyPI
         env:
           PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: Continuous integration
 
-on:
-  push:
-  release:
-    types: [published]
+on: [push]
 
 jobs:
   test:
@@ -58,7 +55,7 @@ jobs:
         with:
           name: junk-drawer
           path: dist
-      - if: github.event_name == 'release'
+      - if: startsWith(github.ref, 'refs/tags/v')
         name: Deploy to PyPI
         env:
           PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,59 +4,68 @@ on: [push]
 
 jobs:
   test:
-    name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: "Test Python ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9.0-rc - 3.9.0']
+        python-version: ["3.7", "3.8", "3.9.0-rc - 3.9.0"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: "Install dependencies"
         run: pip install poetry && poetry install
-      - name: Run tests
+      - name: "Run tests"
         run: poetry run pytest
 
   check:
-    name: Lint and type checks
+    name: "Lint and type checks"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
-      - name: Install dependencies
+          python-version: "3.7"
+      - name: "Install dependencies"
         run: pip install poetry && poetry install
-      - name: Format checks
+      - name: "Format checks"
         run: poetry run black --check .
-      - name: Lint checks
+      - name: "Lint checks"
         run: poetry run flake8
-      - name: Type checks
+      - name: "Type checks"
         run: poetry run mypy
 
   build:
-    name: Build assets and deploy on tags
+    name: "Build assets and deploy on tags"
     runs-on: ubuntu-latest
     needs: [test, check]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
-      - name: Install dependencies
+          python-version: "3.7"
+      - name: "Install dependencies"
         run: pip install poetry
-      - name: Build artifacts
+      - name: "Calculate version"
+        id: version
+        uses: Opentrons/actions/git-version@git-version
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Write version"
+        run: |
+          echo "Version: ${{ steps.version.outputs.version }}"
+          poetry version ${{ steps.version.outputs.version }}
+      - name: "Build artifacts"
         run: poetry build
-      - name: Upload artifacts
+      - name: "Upload artifacts"
         uses: actions/upload-artifact@v2
         with:
           name: junk-drawer
           path: dist
       - if: startsWith(github.ref, 'refs/tags/v')
-        name: Deploy to PyPI
+        name: "Deploy to PyPI"
         env:
           PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9.0-rc - 3.9.0"]
+        os: [ubuntu-latest]
+        python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Continuous integration
 
-on: [push]
+on:
+  push:
+  release:
+    types: [published]
 
 jobs:
   test:
@@ -55,7 +58,7 @@ jobs:
         with:
           name: junk-drawer
           path: dist
-      - if: startsWith(github.ref, 'refs/tags/v')
+      - if: github.event_name == 'release'
         name: Deploy to PyPI
         env:
           PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,30 @@ jobs:
         run: poetry run flake8
       - name: Type checks
         run: poetry run mypy
+
+  build:
+    name: Build assets and deploy on tags
+    runs-on: ubuntu-latest
+    needs: [test, check]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: pip install poetry
+      - name: Build artifacts
+        run: poetry build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: junk-drawer
+          path: dist
+      - if: startsWith(github.ref, "refs/tags/v")
+        name: Deploy to PyPI
+        env:
+          PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry config pypi-token.testpypi $PYPI_TOKEN
+          poetry publish --repository testpypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: Install dependencies
-        run: pip install poetry && poetry install
+        run: pip install poetry
       - id: bump-version
         name: Bump version
         env:
@@ -30,10 +30,12 @@ jobs:
           echo "::set-output name=version::$(poetry version | sed 's/^junk-drawer //')"
       - name: Tag and push
         env:
+          USER_NAME: ${{ github.actor }}
+          USER_ID: ${{ github.event.sender.id }}
           VERSION: ${{ steps.bump-version.outputs.version }}
         run: |
-          git config user.name "Opentrons Labworks"
-          git config user.email "engineering@opentrons.com"
+          git config user.name "$USER_NAME"
+          git config user.email "$USER_ID+$USER_NAME@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore(release): ${VERSION}"
           git tag -a v${VERSION} -m "chore(release): ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GH_PAT }}
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
@@ -28,15 +26,23 @@ jobs:
         run: |
           poetry version $BUMP
           echo "::set-output name=version::$(poetry version | sed 's/^junk-drawer //')"
-      - name: Tag and push
+      - id: commit-version
+        name: Tag and push
         env:
           USER_NAME: ${{ github.actor }}
+          USER_REAL_NAME: ${{ github.event.sender.name }}
           USER_ID: ${{ github.event.sender.id }}
           VERSION: ${{ steps.bump-version.outputs.version }}
         run: |
-          git config user.name "$USER_NAME"
+          git config user.name "$USER_REAL_NAME"
           git config user.email "$USER_ID+$USER_NAME@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore(release): ${VERSION}"
-          git tag -a v${VERSION} -m "chore(release): ${VERSION}"
-          git push --follow-tags
+          git push
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: v${{ steps.bump-version.outputs.version }}
+          release_name: junk-drawer ${{ steps.bump-version.outputs.version }}
+          commitish: ${{ steps.commit-version.outputs.commit }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create release
+name: Create a new release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create a new release
+name: Create release
 
 on:
   workflow_dispatch:
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_PAT }}
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
@@ -26,24 +28,15 @@ jobs:
         run: |
           poetry version $BUMP
           echo "::set-output name=version::$(poetry version | sed 's/^junk-drawer //')"
-      - id: commit-version
-        name: Commit version bump
+      - name: Tag and push
         env:
           USER_NAME: ${{ github.actor }}
           USER_ID: ${{ github.event.sender.id }}
           VERSION: ${{ steps.bump-version.outputs.version }}
         run: |
-          git config user.name "GitHub Actions"
+          git config user.name "$USER_NAME (GitHub Actions)"
           git config user.email "$USER_ID+$USER_NAME@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore(release): ${VERSION}"
-          git push
-          echo "::set-output name=commit::$(git rev-parse HEAD)"
-      - name: Create release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          tag_name: v${{ steps.bump-version.outputs.version }}
-          release_name: junk-drawer ${{ steps.bump-version.outputs.version }}
-          commitish: ${{ steps.commit-version.outputs.commit }}
+          git tag -a v${VERSION} -m "chore(release): ${VERSION}"
+          git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,10 @@ jobs:
         name: Tag and push
         env:
           USER_NAME: ${{ github.actor }}
-          USER_REAL_NAME: ${{ github.event.sender.name }}
           USER_ID: ${{ github.event.sender.id }}
           VERSION: ${{ steps.bump-version.outputs.version }}
         run: |
-          git config user.name "$USER_REAL_NAME"
+          git config user.name "$USER_NAME"
           git config user.email "$USER_ID+$USER_NAME@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore(release): ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           USER_ID: ${{ github.event.sender.id }}
           VERSION: ${{ steps.bump-version.outputs.version }}
         run: |
-          git config user.name "$USER_NAME"
+          git config user.name "GitHub Actions"
           git config user.email "$USER_ID+$USER_NAME@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore(release): ${VERSION}"
@@ -41,6 +41,8 @@ jobs:
           echo "::set-output name=commit::$(git rev-parse HEAD)"
       - name: Create Release
         uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tag_name: v${{ steps.bump-version.outputs.version }}
           release_name: junk-drawer ${{ steps.bump-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Create release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version string or a bump rule from `poetry version`.'
+        required: true
+        default: 'minor'
+
+jobs:
+  release:
+    name: Bump the package version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: pip install poetry && poetry install
+      - id: bump-version
+        name: Bump version
+        env:
+          BUMP: ${{ github.event.inputs.bump }}
+        run: |
+          poetry version $BUMP
+          echo "::set-output name=version::$(poetry version | sed 's/^junk-drawer //')"
+      - name: Tag and push
+        env:
+          VERSION: ${{ steps.bump-version.outputs.version }}
+        run: |
+          git config user.name "Opentrons Labworks"
+          git config user.email "engineering@opentrons.com"
+          git add pyproject.toml
+          git commit -m "chore(release): ${VERSION}"
+          git tag -a v${VERSION} -m "chore(release): ${VERSION}"
+          git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           poetry version $BUMP
           echo "::set-output name=version::$(poetry version | sed 's/^junk-drawer //')"
       - id: commit-version
-        name: Tag and push
+        name: Commit version bump
         env:
           USER_NAME: ${{ github.actor }}
           USER_ID: ${{ github.event.sender.id }}
@@ -39,7 +39,7 @@ jobs:
           git commit -m "chore(release): ${VERSION}"
           git push
           echo "::set-output name=commit::$(git rev-parse HEAD)"
-      - name: Create Release
+      - name: Create release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_PAT }}
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,32 @@ poetry run black . && poetry run flake8 && poetry run mypy && poetry run pytest
 ## Build and Publish Tasks
 
 ```shell
-# build wheel file
+# build wheel and sdist files
 poetry build
 ```
+
+## Releasing
+
+You can create a release by running the [Create a new release][] GitHub Actions workflow. To run the workflow, use the "Run workflow" button on the workflow page, specifying the exact semver version or bump rule. Allowed bump rules are from the [poetry version][] command:
+
+- patch
+- minor
+- major
+- prepatch
+- preminor
+- premajor
+- prerelease
+
+When run, the workflow will:
+
+1. Bump the version in `pyproject.toml`
+2. Commit the bump
+3. Tag the bump commit
+4. Push the tag and commit
+
+The pushed tag will trigger a run of the [Continuous integration][] workflow, which will build the project and deploy it to [PyPI][].
+
+[create a new release]: https://github.com/Opentrons/junk-drawer/actions?query=workflow%3A%22Create+release%22
+[continuous integration]: https://github.com/Opentrons/junk-drawer/actions?query=workflow%3A%22Continuous+integration%22
+[poetry version]: https://python-poetry.org/docs/cli/#version
+[pypi]: https://pypi.org/project/junk-drawer/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+junk_drawer
+Copyright 2020 Opentrons Labworks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/junk_drawer/__init__.py
+++ b/junk_drawer/__init__.py
@@ -2,4 +2,3 @@
 from .store import Store
 
 __all__ = ["Store"]
-__version__ = "0.1.0"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,4 @@
 [mypy]
 files = junk_drawer,tests
-follow_imports = silent
-disallow_untyped_defs = True
-warn_redundant_casts = True
-warn_unused_ignores = True
-warn_return_any = True
-warn_unreachable = True
-strict_equality = True
+strict = True
 show_error_codes = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,7 +65,7 @@ description = "Cross-platform colored terminal text."
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
+version = "0.4.4"
 
 [[package]]
 category = "dev"
@@ -141,7 +141,7 @@ description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
 optional = false
 python-versions = "*"
-version = "1.0.1"
+version = "1.1.1"
 
 [[package]]
 category = "dev"
@@ -170,7 +170,7 @@ description = "Optional static typing for Python"
 name = "mypy"
 optional = false
 python-versions = ">=3.5"
-version = "0.782"
+version = "0.790"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -348,7 +348,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.9.27"
+version = "2020.10.23"
 
 [[package]]
 category = "dev"
@@ -411,14 +411,14 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "3.3.0"
+version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "6c7f77531f45972f06f3a3872f570bd15eadba7d0490bbd4120bdf7b9c731b31"
+content-hash = "dc750e13f8fd6cfbd3870d453046a656c97fdd469e83ce7eff5aebd1ba35eb9a"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -443,8 +443,8 @@ click = [
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
@@ -466,8 +466,8 @@ importlib-metadata = [
     {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
 ]
 iniconfig = [
-    {file = "iniconfig-1.0.1-py3-none-any.whl", hash = "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437"},
-    {file = "iniconfig-1.0.1.tar.gz", hash = "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"},
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -478,20 +478,20 @@ mock = [
     {file = "mock-4.0.2.tar.gz", hash = "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"},
 ]
 mypy = [
-    {file = "mypy-0.782-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c"},
-    {file = "mypy-0.782-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9c7a9a7ceb2871ba4bac1cf7217a7dd9ccd44c27c2950edbc6dc08530f32ad4e"},
-    {file = "mypy-0.782-cp35-cp35m-win_amd64.whl", hash = "sha256:c05b9e4fb1d8a41d41dec8786c94f3b95d3c5f528298d769eb8e73d293abc48d"},
-    {file = "mypy-0.782-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:6731603dfe0ce4352c555c6284c6db0dc935b685e9ce2e4cf220abe1e14386fd"},
-    {file = "mypy-0.782-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:f05644db6779387ccdb468cc47a44b4356fc2ffa9287135d05b70a98dc83b89a"},
-    {file = "mypy-0.782-cp36-cp36m-win_amd64.whl", hash = "sha256:b7fbfabdbcc78c4f6fc4712544b9b0d6bf171069c6e0e3cb82440dd10ced3406"},
-    {file = "mypy-0.782-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:3fdda71c067d3ddfb21da4b80e2686b71e9e5c72cca65fa216d207a358827f86"},
-    {file = "mypy-0.782-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7df6eddb6054d21ca4d3c6249cae5578cb4602951fd2b6ee2f5510ffb098707"},
-    {file = "mypy-0.782-cp37-cp37m-win_amd64.whl", hash = "sha256:a4a2cbcfc4cbf45cd126f531dedda8485671545b43107ded25ce952aac6fb308"},
-    {file = "mypy-0.782-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6bb93479caa6619d21d6e7160c552c1193f6952f0668cdda2f851156e85186fc"},
-    {file = "mypy-0.782-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:81c7908b94239c4010e16642c9102bfc958ab14e36048fa77d0be3289dda76ea"},
-    {file = "mypy-0.782-cp38-cp38-win_amd64.whl", hash = "sha256:5dd13ff1f2a97f94540fd37a49e5d255950ebcdf446fb597463a40d0df3fac8b"},
-    {file = "mypy-0.782-py3-none-any.whl", hash = "sha256:e0b61738ab504e656d1fe4ff0c0601387a5489ca122d55390ade31f9ca0e252d"},
-    {file = "mypy-0.782.tar.gz", hash = "sha256:eff7d4a85e9eea55afa34888dfeaccde99e7520b51f867ac28a48492c0b1130c"},
+    {file = "mypy-0.790-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:bd03b3cf666bff8d710d633d1c56ab7facbdc204d567715cb3b9f85c6e94f669"},
+    {file = "mypy-0.790-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:2170492030f6faa537647d29945786d297e4862765f0b4ac5930ff62e300d802"},
+    {file = "mypy-0.790-cp35-cp35m-win_amd64.whl", hash = "sha256:e86bdace26c5fe9cf8cb735e7cedfe7850ad92b327ac5d797c656717d2ca66de"},
+    {file = "mypy-0.790-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e97e9c13d67fbe524be17e4d8025d51a7dca38f90de2e462243ab8ed8a9178d1"},
+    {file = "mypy-0.790-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0d34d6b122597d48a36d6c59e35341f410d4abfa771d96d04ae2c468dd201abc"},
+    {file = "mypy-0.790-cp36-cp36m-win_amd64.whl", hash = "sha256:72060bf64f290fb629bd4a67c707a66fd88ca26e413a91384b18db3876e57ed7"},
+    {file = "mypy-0.790-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:eea260feb1830a627fb526d22fbb426b750d9f5a47b624e8d5e7e004359b219c"},
+    {file = "mypy-0.790-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c614194e01c85bb2e551c421397e49afb2872c88b5830e3554f0519f9fb1c178"},
+    {file = "mypy-0.790-cp37-cp37m-win_amd64.whl", hash = "sha256:0a0d102247c16ce93c97066443d11e2d36e6cc2a32d8ccc1f705268970479324"},
+    {file = "mypy-0.790-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cf4e7bf7f1214826cf7333627cb2547c0db7e3078723227820d0a2490f117a01"},
+    {file = "mypy-0.790-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:af4e9ff1834e565f1baa74ccf7ae2564ae38c8df2a85b057af1dbbc958eb6666"},
+    {file = "mypy-0.790-cp38-cp38-win_amd64.whl", hash = "sha256:da56dedcd7cd502ccd3c5dddc656cb36113dd793ad466e894574125945653cea"},
+    {file = "mypy-0.790-py3-none-any.whl", hash = "sha256:2842d4fbd1b12ab422346376aad03ff5d0805b706102e475e962370f874a5122"},
+    {file = "mypy-0.790.tar.gz", hash = "sha256:2b21ba45ad9ef2e2eb88ce4aeadd0112d0f5026418324176fd494a6824b74975"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -563,27 +563,33 @@ pytest-watch = [
     {file = "pytest-watch-4.2.0.tar.gz", hash = "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9"},
 ]
 regex = [
-    {file = "regex-2020.9.27-cp27-cp27m-win32.whl", hash = "sha256:d23a18037313714fb3bb5a94434d3151ee4300bae631894b1ac08111abeaa4a3"},
-    {file = "regex-2020.9.27-cp27-cp27m-win_amd64.whl", hash = "sha256:84e9407db1b2eb368b7ecc283121b5e592c9aaedbe8c78b1a2f1102eb2e21d19"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5f18875ac23d9aa2f060838e8b79093e8bb2313dbaaa9f54c6d8e52a5df097be"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ae91972f8ac958039920ef6e8769277c084971a142ce2b660691793ae44aae6b"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9a02d0ae31d35e1ec12a4ea4d4cca990800f66a917d0fb997b20fbc13f5321fc"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ebbe29186a3d9b0c591e71b7393f1ae08c83cb2d8e517d2a822b8f7ec99dfd8b"},
-    {file = "regex-2020.9.27-cp36-cp36m-win32.whl", hash = "sha256:4707f3695b34335afdfb09be3802c87fa0bc27030471dbc082f815f23688bc63"},
-    {file = "regex-2020.9.27-cp36-cp36m-win_amd64.whl", hash = "sha256:9bc13e0d20b97ffb07821aa3e113f9998e84994fe4d159ffa3d3a9d1b805043b"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f1b3afc574a3db3b25c89161059d857bd4909a1269b0b3cb3c904677c8c4a3f7"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5533a959a1748a5c042a6da71fe9267a908e21eded7a4f373efd23a2cbdb0ecc"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:1fe0a41437bbd06063aa184c34804efa886bcc128222e9916310c92cd54c3b4c"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:c570f6fa14b9c4c8a4924aaad354652366577b4f98213cf76305067144f7b100"},
-    {file = "regex-2020.9.27-cp37-cp37m-win32.whl", hash = "sha256:eda4771e0ace7f67f58bc5b560e27fb20f32a148cbc993b0c3835970935c2707"},
-    {file = "regex-2020.9.27-cp37-cp37m-win_amd64.whl", hash = "sha256:60b0e9e6dc45683e569ec37c55ac20c582973841927a85f2d8a7d20ee80216ab"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux1_i686.whl", hash = "sha256:088afc8c63e7bd187a3c70a94b9e50ab3f17e1d3f52a32750b5b77dbe99ef5ef"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:eaf548d117b6737df379fdd53bdde4f08870e66d7ea653e230477f071f861121"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:41bb65f54bba392643557e617316d0d899ed5b4946dccee1cb6696152b29844b"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8d69cef61fa50c8133382e61fd97439de1ae623fe943578e477e76a9d9471637"},
-    {file = "regex-2020.9.27-cp38-cp38-win32.whl", hash = "sha256:f2388013e68e750eaa16ccbea62d4130180c26abb1d8e5d584b9baf69672b30f"},
-    {file = "regex-2020.9.27-cp38-cp38-win_amd64.whl", hash = "sha256:4318d56bccfe7d43e5addb272406ade7a2274da4b70eb15922a071c58ab0108c"},
-    {file = "regex-2020.9.27.tar.gz", hash = "sha256:a6f32aea4260dfe0e55dc9733ea162ea38f0ea86aa7d0f77b15beac5bf7b369d"},
+    {file = "regex-2020.10.23-cp27-cp27m-win32.whl", hash = "sha256:781906e45ef1d10a0ed9ec8ab83a09b5e0d742de70e627b20d61ccb1b1d3964d"},
+    {file = "regex-2020.10.23-cp27-cp27m-win_amd64.whl", hash = "sha256:8cd0d587aaac74194ad3e68029124c06245acaeddaae14cb45844e5c9bebeea4"},
+    {file = "regex-2020.10.23-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:af360e62a9790e0a96bc9ac845d87bfa0e4ee0ee68547ae8b5a9c1030517dbef"},
+    {file = "regex-2020.10.23-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e21340c07090ddc8c16deebfd82eb9c9e1ec5e62f57bb86194a2595fd7b46e0"},
+    {file = "regex-2020.10.23-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:e5f6aa56dda92472e9d6f7b1e6331f4e2d51a67caafff4d4c5121cadac03941e"},
+    {file = "regex-2020.10.23-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:c30d8766a055c22e39dd7e1a4f98f6266169f2de05db737efe509c2fb9c8a3c8"},
+    {file = "regex-2020.10.23-cp36-cp36m-win32.whl", hash = "sha256:1a065e7a6a1b4aa851a0efa1a2579eabc765246b8b3a5fd74000aaa3134b8b4e"},
+    {file = "regex-2020.10.23-cp36-cp36m-win_amd64.whl", hash = "sha256:c95d514093b80e5309bdca5dd99e51bcf82c44043b57c34594d9d7556bd04d05"},
+    {file = "regex-2020.10.23-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f4b1c65ee86bfbf7d0c3dfd90592a9e3d6e9ecd36c367c884094c050d4c35d04"},
+    {file = "regex-2020.10.23-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d62205f00f461fe8b24ade07499454a3b7adf3def1225e258b994e2215fd15c5"},
+    {file = "regex-2020.10.23-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b706c70070eea03411b1761fff3a2675da28d042a1ab7d0863b3efe1faa125c9"},
+    {file = "regex-2020.10.23-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d43cf21df524283daa80ecad551c306b7f52881c8d0fe4e3e76a96b626b6d8d8"},
+    {file = "regex-2020.10.23-cp37-cp37m-win32.whl", hash = "sha256:570e916a44a361d4e85f355aacd90e9113319c78ce3c2d098d2ddf9631b34505"},
+    {file = "regex-2020.10.23-cp37-cp37m-win_amd64.whl", hash = "sha256:1c447b0d108cddc69036b1b3910fac159f2b51fdeec7f13872e059b7bc932be1"},
+    {file = "regex-2020.10.23-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8469377a437dbc31e480993399fd1fd15fe26f382dc04c51c9cb73e42965cc06"},
+    {file = "regex-2020.10.23-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:59d5c6302d22c16d59611a9fd53556554010db1d47e9df5df37be05007bebe75"},
+    {file = "regex-2020.10.23-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a973d5a7a324e2a5230ad7c43f5e1383cac51ef4903bf274936a5634b724b531"},
+    {file = "regex-2020.10.23-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:97a023f97cddf00831ba04886d1596ef10f59b93df7f855856f037190936e868"},
+    {file = "regex-2020.10.23-cp38-cp38-win32.whl", hash = "sha256:e289a857dca3b35d3615c3a6a438622e20d1bf0abcb82c57d866c8d0be3f44c4"},
+    {file = "regex-2020.10.23-cp38-cp38-win_amd64.whl", hash = "sha256:0cb23ed0e327c18fb7eac61ebbb3180ebafed5b9b86ca2e15438201e5903b5dd"},
+    {file = "regex-2020.10.23-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c53dc8ee3bb7b7e28ee9feb996a0c999137be6c1d3b02cb6b3c4cba4f9e5ed09"},
+    {file = "regex-2020.10.23-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6a46eba253cedcbe8a6469f881f014f0a98819d99d341461630885139850e281"},
+    {file = "regex-2020.10.23-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:240509721a663836b611fa13ca1843079fc52d0b91ef3f92d9bba8da12e768a0"},
+    {file = "regex-2020.10.23-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f567df0601e9c7434958143aebea47a9c4b45434ea0ae0286a4ec19e9877169"},
+    {file = "regex-2020.10.23-cp39-cp39-win32.whl", hash = "sha256:bfd7a9fddd11d116a58b62ee6c502fd24cfe22a4792261f258f886aa41c2a899"},
+    {file = "regex-2020.10.23-cp39-cp39-win_amd64.whl", hash = "sha256:1a511470db3aa97432ac8c1bf014fcc6c9fbfd0f4b1313024d342549cf86bcd6"},
+    {file = "regex-2020.10.23.tar.gz", hash = "sha256:2278453c6a76280b38855a263198961938108ea2333ee145c5168c36b8e2b376"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -629,6 +635,6 @@ watchdog = [
     {file = "watchdog-0.10.3.tar.gz", hash = "sha256:4214e1379d128b0588021880ccaf40317ee156d4603ac388b9adcf29165e0c04"},
 ]
 zipp = [
-    {file = "zipp-3.3.0-py3-none-any.whl", hash = "sha256:eed8ec0b8d1416b2ca33516a37a08892442f3954dee131e92cfd92d8fe3e7066"},
-    {file = "zipp-3.3.0.tar.gz", hash = "sha256:64ad89efee774d1897a58607895d80789c59778ea02185dd846ac38394a8642b"},
+    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
+    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.2.0-alpha.0"
+version = "0.2.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.1.0"
+version = "0.0.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.2.0"
+version = "0.2.1-alpha.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.2.1-alpha.0"
+version = "0.3.0-alpha.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.0.0"
+version = "0.1.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.3.0-alpha.0"
+version = "0.3.0-alpha.1"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.0.0"
+version = "0.1.0-alpha.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.0.0"
+version = "0.0.1-alpha.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,30 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.1.0"
+version = "0.0.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
+license = "Apache-2.0"
+readme = "README.md"
+
+homepage = "https://github.com/Opentrons/junk-drawer"
+repository = "https://github.com/Opentrons/junk-drawer"
+documentation = "https://github.com/Opentrons/junk-drawer#readme"
+
+include = [
+  "LICENSE",
+  "NOTICE"
+]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pydantic = "^1.6.1"
+pydantic = "^1.4"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
 flake8 = "^3.8.3"
 flake8-docstrings = "^1.5.0"
 mock = "^4.0.2"
-mypy = "^0.782"
+mypy = "^0.790"
 pytest = "^6.1.0"
 pytest-watch = "^4.2.0"
 pytest-asyncio = "^0.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "junk-drawer"
-version = "0.1.0"
+version = "0.2.0-alpha.0"
 description = "Simple JSON data storage on the filesystem"
 authors = ["Opentrons Labworks <engineering@opentrons.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## overview

This PR adds a GitHub actions-based release-to-PyPI flow which looks like:

1. Manually trigger the `release` workflow via a `workflow_dispatch`  
    <img width="394" alt="Screen Shot 2020-10-27 at 15 20 51" src="https://user-images.githubusercontent.com/2963448/97351350-02593c00-1868-11eb-94f2-c632b90ed0dd.png">
2. `release` workflow will:
    - Update `pyproject.toml`
    - Tag the release
    - Push the release commit and tag
3. Regular `ci` workflow will catch the tag push and
    - Run tests and lints as normal
    - Recognize the tag build and upload to PyPI as necessary

**Note: currently hooked to test.pypi.org for testing purposes. Requires a switch before merge**

## change log

- ci: add release and publish workflows

## review requests

- [ ] Is this a good idea?
    - Note: to have the `release` workflow trigger the `ci` workflow, I had to add a Personal Access Token from @opentrons-engineering to the repo secrets
    - The default GitHub Token in Actions is set up to avoid triggering other workflows to prevent accidental recursion
    - Recursion isn't a risk here because `release` is always manually triggered
- [ ] If "yes", how does this look?

### how to test

**This will affect this branch** (which is OK while we're only hooked to test.pypi.org)

1. Go to the ["Create release" workflow](https://github.com/Opentrons/junk-drawer/actions?query=workflow%3A%22Create+release%22)
2. Trigger a workflow run on the `publishing` branch
3. Watch the runs happen!
    - A tag will be created and pushed
    - That tag will trigger a build and publish

### stuff considered and/or tried but left out

- I wanted to create a GH release and upload the wheel and sdist assets to the release, but the "official" available actions aren't really up to the task
    - Definitely possible with a custom action if we wanted to bother

### alternatives

This was a bit of an experiment to play around with GitHub actions. We could (and maybe should) consider something more in line with what we're moving towards for the monorepo:

0. `pyproject.toml` always has `0.0.0-dev` as its version
1. "Create release" workflow tags the commit and pushes the tag
2. "Continuous integration" workflow uses `git describe` to write a concrete version to `pyproject.toml` and produces build artifacts
3. If `git describe` outputs an actual version, publish to PyPI