### PR TITLE
feat: add read-only store interface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ All tasks should be run in the virtualenv by using `poetry run` or by activating
 poetry run pytest
 
 # run tests in watch mode
-poetry run ptw
+poetry run pytest --looponfail --color="yes"
 
 # run formatting
 poetry run black .

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ class MyModel(BaseModel):
     name: str
 
 async def main():
-    store = await Store.create("path/to/store", schema=MyModel)
+    store = Store.create("path/to/store", schema=MyModel)
 ```
 
 A store can be used to save and retrieve multiple items conforming to the same schema. Use [Pydantic][] to define your model shape. When this store is created, it will create the directory `${cwd}/path/to/store` if it doesn't already exist.
@@ -35,7 +35,7 @@ A store can be used to save and retrieve multiple items conforming to the same s
 
 ```py
 async def main():
-    store = await Store.create("path/to/store", schema=MyModel)
+    store = Store.create("path/to/store", schema=MyModel)
     item = await store.get("some-key")
 ```
 
@@ -57,7 +57,7 @@ The store has the following methods for getting items and keys from the store.
 ```py
 async def main():
     item = MyModel(name="fizzbuzz")
-    store = await Store.create("path/to/store", schema=MyModel)
+    store = Store.create("path/to/store", schema=MyModel)
     item_key = await store.put(item, "some-key")
 ```
 
@@ -85,7 +85,7 @@ class KeyedModel(BaseModel):
 
 async def main():
     item = ModelWithKey(uid=uuid4(), name="fizzbuzz")
-    store = await Store.create("store", schema=KeyedModel, primary_key="uid")
+    store = Store.create("store", schema=KeyedModel, primary_key="uid")
     item_key = await store.put(item)
 ```
 
@@ -96,7 +96,7 @@ If you specify the `primary_key` option when creating the store, `put` and `ensu
 ```py
 async def main():
     item = MyModel(name="fizzbuzz")
-    store = await Store.create("path/to/store", schema=MyModel)
+    store = Store.create("path/to/store", schema=MyModel)
 
     removed_key = await store.delete("some-key")
 ```
@@ -123,7 +123,7 @@ def migration_v2(prev: Dict[str, Any]) -> Dict[str, Any]:
     return next_model
 
 async def main():
-    store = await Store.create(
+    store = Store.create(
         "./data/existing_store",
         schema=MyModel,
         migrations=(migration_v1, migration_v2)
@@ -182,7 +182,7 @@ class MyModel(BaseModel):
     name: str
 
 async def main():
-    store = await Store.create("path/to/store", schema=MyModel)
+    store = Store.create("path/to/store", schema=MyModel)
 ```
 
 Creates a `Store` instance to store items in a given directory relative to the current working directory. Do not configure multiple stores for the same directory.
@@ -201,7 +201,7 @@ class Scissors(BaseModel):
   left_handed: bool
 
 async def main():
-    store = await Store.create("scissors", schema=Scissors)
+    store = Store.create("scissors", schema=Scissors)
     scissors = await store.get("my-scissors")
 ```
 
@@ -217,7 +217,7 @@ class Scissors(BaseModel):
   left_handed: bool
 
 async def main():
-    store = await Store.create("scissors", schema=Scissors)
+    store = Store.create("scissors", schema=Scissors)
     all_scissors = await store.get_all_items()
 ```
 
@@ -233,7 +233,7 @@ class Scissors(BaseModel):
   left_handed: bool
 
 async def main():
-    store = await Store.create("scissors", schema=Scissors)
+    store = Store.create("scissors", schema=Scissors)
     all_scissor_keys = await store.get_all_keys()
 ```
 
@@ -249,7 +249,7 @@ class Scissors(BaseModel):
   left_handed: bool
 
 async def main():
-    store = await Store.create("scissors", schema=Scissors)
+    store = Store.create("scissors", schema=Scissors)
     all_scissor_entries = await store.get_all_entries()
 ```
 
@@ -270,7 +270,7 @@ class Scissors(BaseModel):
   left_handed: bool
 
 async def main():
-    store = await Store.create("scissors", schema=Scissors)
+    store = Store.create("scissors", schema=Scissors)
     scissors = Scissors(left_handed=true)
     scissors_key = await store.put(scissors, "my-scissors")
 ```
@@ -293,7 +293,7 @@ class Scissors(BaseModel):
 
 async def main():
     default_scissors = Scissors(left_handed=true)
-    store = await Store.create("scissors", schema=Scissors)
+    store = Store.create("scissors", schema=Scissors)
     scissors = await store.ensure(default_scissors, "my-scissors")
 ```
 
@@ -313,7 +313,7 @@ class Scissors(BaseModel):
   left_handed: bool
 
 async def main():
-    store = await Store.create("scissors", schema=Scissors)
+    store = Store.create("scissors", schema=Scissors)
     scissors_key = await store.put(Scissors(left_handed=true), "key")
     await store.delete(scissors_key)
 ```
@@ -330,7 +330,7 @@ class Scissors(BaseModel):
   left_handed: bool
 
 async def main():
-    store = await Store.create("scissors", schema=Scissors)
+    store = Store.create("scissors", schema=Scissors)
     await store.delete_store()
 ```
 

--- a/junk_drawer/__init__.py
+++ b/junk_drawer/__init__.py
@@ -1,5 +1,6 @@
 """Top-level module for junk_drawer."""
 from .store import Store
+from .read_store import ReadStore
 
-__all__ = ["Store"]
+__all__ = ["Store", "ReadStore"]
 __version__ = "0.1.0"

--- a/junk_drawer/filesystem/async_filesystem.py
+++ b/junk_drawer/filesystem/async_filesystem.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import get_event_loop, gather, AbstractEventLoop
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from pathlib import PurePath
+from pathlib import PurePath, PurePosixPath
 from typing import List, Optional
 
 from .base import (
@@ -96,7 +96,7 @@ class AsyncFilesystem(AsyncFilesystemLike):
         """Read and parse all JSON files in a directory concurrently."""
 
         async def _read_entry(child: str) -> DirectoryEntry[ResultT]:
-            child_path = path / child
+            child_path = PurePosixPath(path / child)
             child_contents = await self.read_json(child_path, parse_json)
             return DirectoryEntry(path=child_path, contents=child_contents)
 

--- a/junk_drawer/filesystem/async_filesystem.py
+++ b/junk_drawer/filesystem/async_filesystem.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import get_event_loop, gather, AbstractEventLoop
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from pathlib import PurePath, PurePosixPath
+from pathlib import PurePosixPath
 from typing import List, Optional
 
 from .base import (
@@ -59,25 +59,25 @@ class AsyncFilesystem(AsyncFilesystemLike):
         """Get the underlying synchronous filesystem interface."""
         return self._sync_filesystem
 
-    async def ensure_dir(self, path: PurePath) -> PurePath:
+    async def ensure_dir(self, path: PurePosixPath) -> PurePosixPath:
         """Ensure a directory at `path` exists, creating it if it doesn't."""
         task = partial(self.sync.ensure_dir, path=path)
         await self._loop.run_in_executor(self._executor, task)
         return path
 
-    async def read_dir(self, path: PurePath) -> List[str]:
+    async def read_dir(self, path: PurePosixPath) -> List[str]:
         """Get the stem names of all JSON files in the directory."""
         task = partial(self.sync.read_dir, path=path)
         return await self._loop.run_in_executor(self._executor, task)
 
-    async def file_exists(self, path: PurePath) -> bool:
+    async def file_exists(self, path: PurePosixPath) -> bool:
         """Return True if `{path}.json` is a file."""
         task = partial(self.sync.file_exists, path=path)
         return await self._loop.run_in_executor(self._executor, task)
 
     async def read_json(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         parse_json: JSONParser[ResultT] = default_parse_json,
     ) -> ResultT:
         """Read and parse a single JSON file."""
@@ -89,7 +89,7 @@ class AsyncFilesystem(AsyncFilesystemLike):
 
     async def read_json_dir(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         parse_json: JSONParser[ResultT] = default_parse_json,
         ignore_errors: bool = False,
     ) -> List[DirectoryEntry[ResultT]]:
@@ -111,7 +111,7 @@ class AsyncFilesystem(AsyncFilesystemLike):
 
     async def write_json(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         contents: ResultT,
         encode_json: JSONEncoder[ResultT] = default_encode_json,
     ) -> None:
@@ -122,13 +122,13 @@ class AsyncFilesystem(AsyncFilesystemLike):
 
         return await self._loop.run_in_executor(self._executor, task)
 
-    async def remove(self, path: PurePath) -> None:
+    async def remove(self, path: PurePosixPath) -> None:
         """Delete a JSON file."""
         task = partial(self.sync.remove, path=path)
 
         return await self._loop.run_in_executor(self._executor, task)
 
-    async def remove_dir(self, path: PurePath) -> None:
+    async def remove_dir(self, path: PurePosixPath) -> None:
         """Delete all files in the given directory and the directory."""
         task = partial(self.sync.remove_dir, path=path)
 

--- a/junk_drawer/filesystem/base.py
+++ b/junk_drawer/filesystem/base.py
@@ -2,7 +2,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from json import loads as json_loads, dumps as json_dumps
-from pathlib import PurePath
+from pathlib import PurePosixPath
 from typing import Any, Callable, Generic, List, TypeVar
 
 
@@ -13,7 +13,7 @@ ResultT = TypeVar("ResultT")
 class DirectoryEntry(Generic[ResultT]):
     """Filename and parsed file contents from a full directory read."""
 
-    path: PurePath
+    path: PurePosixPath
     contents: ResultT
 
 
@@ -35,34 +35,34 @@ class SyncFilesystemLike(ABC):
     """Abstract synchronous filesystem interface."""
 
     @abstractmethod
-    def ensure_dir(self, path: PurePath) -> PurePath:
+    def ensure_dir(self, path: PurePosixPath) -> PurePosixPath:
         """Ensure a directory at `path` exists, creating it if it doesn't."""
         ...
 
     @abstractmethod
-    def read_dir(self, path: PurePath) -> List[str]:
+    def read_dir(self, path: PurePosixPath) -> List[str]:
         """Get the stem names of all JSON files in the directory."""
         ...
 
     @abstractmethod
-    def remove_dir(self, path: PurePath) -> None:
+    def remove_dir(self, path: PurePosixPath) -> None:
         """Delete a directory and everything in it."""
         ...
 
     @abstractmethod
-    def remove(self, path: PurePath) -> None:
+    def remove(self, path: PurePosixPath) -> None:
         """Delete the file at {path}.json."""
         ...
 
     @abstractmethod
-    def file_exists(self, path: PurePath) -> bool:
+    def file_exists(self, path: PurePosixPath) -> bool:
         """Return True if `{path}.json` is a file."""
         ...
 
     @abstractmethod
     def read_json(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         parse_json: JSONParser[ResultT],
     ) -> ResultT:
         """Read and parse a single JSON file."""
@@ -71,7 +71,7 @@ class SyncFilesystemLike(ABC):
     @abstractmethod
     def read_json_dir(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         parse_json: JSONParser[ResultT],
         ignore_errors: bool,
     ) -> List[DirectoryEntry[ResultT]]:
@@ -81,7 +81,7 @@ class SyncFilesystemLike(ABC):
     @abstractmethod
     def write_json(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         contents: ResultT,
         encode_json: JSONEncoder[ResultT],
     ) -> None:
@@ -99,34 +99,34 @@ class AsyncFilesystemLike(ABC):
         ...
 
     @abstractmethod
-    async def ensure_dir(self, path: PurePath) -> PurePath:
+    async def ensure_dir(self, path: PurePosixPath) -> PurePosixPath:
         """Ensure a directory at `path` exists, creating it if it doesn't."""
         ...
 
     @abstractmethod
-    async def read_dir(self, path: PurePath) -> List[str]:
+    async def read_dir(self, path: PurePosixPath) -> List[str]:
         """Get the stem names of all JSON files in the directory."""
         ...
 
     @abstractmethod
-    async def remove_dir(self, path: PurePath) -> None:
+    async def remove_dir(self, path: PurePosixPath) -> None:
         """Delete a directory and everything in it."""
         ...
 
     @abstractmethod
-    async def remove(self, path: PurePath) -> None:
+    async def remove(self, path: PurePosixPath) -> None:
         """Delete the file at {path}.json."""
         ...
 
     @abstractmethod
-    async def file_exists(self, path: PurePath) -> bool:
+    async def file_exists(self, path: PurePosixPath) -> bool:
         """Return True if `{path}.json` is a file."""
         ...
 
     @abstractmethod
     async def read_json(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         parse_json: JSONParser[ResultT],
     ) -> ResultT:
         """Read and parse a single JSON file."""
@@ -135,7 +135,7 @@ class AsyncFilesystemLike(ABC):
     @abstractmethod
     async def read_json_dir(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         parse_json: JSONParser[ResultT],
         ignore_errors: bool,
     ) -> List[DirectoryEntry[ResultT]]:
@@ -145,7 +145,7 @@ class AsyncFilesystemLike(ABC):
     @abstractmethod
     async def write_json(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         contents: ResultT,
         encode_json: JSONEncoder[ResultT],
     ) -> None:

--- a/junk_drawer/filesystem/sync_filesystem.py
+++ b/junk_drawer/filesystem/sync_filesystem.py
@@ -1,6 +1,6 @@
 """Synchronous JSON filesystem."""
 from logging import getLogger
-from pathlib import Path, PurePath, PurePosixPath
+from pathlib import Path, PurePosixPath
 from shutil import rmtree
 from typing import List, Optional
 
@@ -30,12 +30,12 @@ log = getLogger(__name__)
 class SyncFilesystem(SyncFilesystemLike):
     """Synchronous JSON filesystem adapter."""
 
-    def ensure_dir(self, path: PurePath) -> PurePath:
+    def ensure_dir(self, path: PurePosixPath) -> PurePosixPath:
         """Ensure a directory at `path` exists, creating it if it doesn't."""
         Path(path).mkdir(parents=True, exist_ok=True)
         return path
 
-    def read_dir(self, path: PurePath) -> List[str]:
+    def read_dir(self, path: PurePosixPath) -> List[str]:
         """Get the stem names of all JSON files in the directory."""
         file_paths = Path(path).glob("**/*.json")
 
@@ -45,13 +45,13 @@ class SyncFilesystem(SyncFilesystemLike):
             if not file_path.stem.startswith(".")
         ]
 
-    def file_exists(self, path: PurePath) -> bool:
+    def file_exists(self, path: PurePosixPath) -> bool:
         """Return True if `{path}.json` is a file."""
         return Path(path.with_suffix(".json")).is_file()
 
     def read_json(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         parse_json: JSONParser[ResultT] = default_parse_json,
     ) -> ResultT:
         """Read and parse a single JSON file."""
@@ -78,7 +78,7 @@ class SyncFilesystem(SyncFilesystemLike):
 
     def read_json_dir(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         parse_json: JSONParser[ResultT] = default_parse_json,
         ignore_errors: bool = False,
     ) -> List[DirectoryEntry[ResultT]]:
@@ -103,7 +103,7 @@ class SyncFilesystem(SyncFilesystemLike):
 
     def write_json(
         self,
-        path: PurePath,
+        path: PurePosixPath,
         contents: ResultT,
         encode_json: JSONEncoder[ResultT] = default_encode_json,
     ) -> None:
@@ -117,7 +117,7 @@ class SyncFilesystem(SyncFilesystemLike):
             raise FileEncodeError(str(error)) from error
 
         try:
-            self.ensure_dir(file_path.parent)
+            self.ensure_dir(path.parent)
             file_path.write_text(encoded_contents)
         except Exception as error:
             # NOTE: this except branch is not covered by tests, but is important
@@ -126,7 +126,7 @@ class SyncFilesystem(SyncFilesystemLike):
 
         return None
 
-    def remove(self, path: PurePath) -> None:
+    def remove(self, path: PurePosixPath) -> None:
         """Delete a JSON file."""
         file_path = Path(path.with_suffix(".json"))
 
@@ -141,7 +141,7 @@ class SyncFilesystem(SyncFilesystemLike):
 
         return None
 
-    def remove_dir(self, path: PurePath) -> None:
+    def remove_dir(self, path: PurePosixPath) -> None:
         """Delete all files in the given directory and the directory."""
         rmtree(path=path)
 

--- a/junk_drawer/read_store.py
+++ b/junk_drawer/read_store.py
@@ -1,0 +1,216 @@
+"""Read-only store module for junk_drawer."""
+from __future__ import annotations
+from logging import getLogger
+from pathlib import PurePath, PurePosixPath
+from pydantic import BaseModel
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Type,
+    Union,
+)
+
+from .errors import ItemDecodeError, ItemEncodeError, ItemAccessError
+
+from .filesystem import (
+    AsyncFilesystemLike,
+    AsyncFilesystem,
+    PathNotFoundError,
+    RemoveFileError,
+    FileEncodeError,
+    FileReadError,
+    FileParseError,
+    FileWriteError,
+    FileError,
+)
+
+
+SCHEMA_VERSION_KEY = "__schema_version__"
+
+StoreT = TypeVar("StoreT", bound="ReadStore")
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+Migration = Callable[[Dict[str, Any]], Dict[str, Any]]
+
+log = getLogger(__name__)
+
+
+class ReadStore(Generic[ModelT]):
+    """A Store class is used to manage reading a collection of items."""
+
+    @classmethod
+    def create(
+        cls: Type[StoreT],
+        directory: Union[str, PurePath],
+        schema: Type[ModelT],
+        *,
+        primary_key: Optional[str] = None,
+        migrations: Sequence[Migration] = (),
+        ignore_errors: bool = False,
+    ) -> StoreT:
+        """Create a new ReadStore."""
+        directory = PurePath(directory)
+        filesystem = AsyncFilesystem.create()
+
+        return cls(
+            directory=directory,
+            schema=schema,
+            migrations=migrations,
+            primary_key=primary_key,
+            ignore_errors=ignore_errors,
+            filesystem=filesystem,
+        )
+
+    def __init__(
+        self,
+        directory: PurePath,
+        schema: Type[ModelT],
+        *,
+        primary_key: Optional[str],
+        migrations: Sequence[Migration],
+        ignore_errors: bool,
+        filesystem: AsyncFilesystemLike,
+    ) -> None:
+        """Initialize a Store; use Store.create instead."""
+        self._directory = directory
+        self._schema = schema
+        self._migrations = migrations
+        self._primary_key = primary_key
+        self._filesystem = filesystem
+        self._ignore_errors = ignore_errors
+
+    async def exists(self, key: str) -> bool:
+        """Check whether a key exists in the store."""
+        key_path = self._get_key_path(key)
+        return await self._filesystem.file_exists(key_path)
+
+    def exists_sync(self, key: str) -> bool:
+        """
+        Check whether a key exists in the store.
+
+        Synchronous version of :py:meth:`exists`.
+        """
+        key_path = self._get_key_path(key)
+        return self._filesystem.sync.file_exists(key_path)
+
+    async def get(self, key: str) -> Optional[ModelT]:
+        """Get an item from the store by key, if that key exists."""
+        key_path = self._get_key_path(key)
+
+        try:
+            return await self._filesystem.read_json(
+                key_path, parse_json=self.parse_json
+            )
+        except (PathNotFoundError, FileParseError, FileReadError) as error:
+            self._maybe_raise_file_error(error)
+            return None
+
+    def get_sync(self, key: str) -> Optional[ModelT]:
+        """
+        Get an item from the store by key, if that key exists.
+
+        Synchronous version of :py:meth:`get`.
+        """
+        key_path = self._get_key_path(key)
+
+        try:
+            return self._filesystem.sync.read_json(key_path, parse_json=self.parse_json)
+        except (PathNotFoundError, FileParseError, FileReadError) as error:
+            self._maybe_raise_file_error(error)
+            return None
+
+    async def get_all_keys(self) -> List[str]:
+        """Get all keys in the store."""
+        return await self._filesystem.read_dir(self._directory)
+
+    def get_all_keys_sync(self) -> List[str]:
+        """
+        Get all keys in the store.
+
+        Synchronous version of :py:meth:`get_all_keys`.
+        """
+        return self._filesystem.sync.read_dir(self._directory)
+
+    async def get_all_entries(self) -> List[Tuple[str, ModelT]]:
+        """Get all key, item entry pairs in the store."""
+        try:
+            dir_entries = await self._filesystem.read_json_dir(
+                self._directory,
+                parse_json=self.parse_json,
+                ignore_errors=self._ignore_errors,
+            )
+        except (PathNotFoundError, FileParseError, FileReadError) as error:
+            self._maybe_raise_file_error(error)
+
+        return [(entry.path.stem, entry.contents) for entry in dir_entries]
+
+    def get_all_entries_sync(self) -> List[Tuple[str, ModelT]]:
+        """
+        Get all key, item entry pairs in the store.
+
+        Synchronous version of :py:meth:`get_all_entries`.
+        """
+        try:
+            dir_entries = self._filesystem.sync.read_json_dir(
+                self._directory,
+                parse_json=self.parse_json,
+                ignore_errors=self._ignore_errors,
+            )
+        except (PathNotFoundError, FileParseError, FileReadError) as error:
+            self._maybe_raise_file_error(error)
+
+        return [(entry.path.stem, entry.contents) for entry in dir_entries]
+
+    async def get_all_items(self) -> List[ModelT]:
+        """Get all items in the store."""
+        entries = await self.get_all_entries()
+        return [item for key, item in entries]
+
+    def get_all_items_sync(self) -> List[ModelT]:
+        """
+        Get all items in the store.
+
+        Synchronous version of :py:meth:`get_all_items`.
+        """
+        entries = self.get_all_entries_sync()
+        return [item for key, item in entries]
+
+    def parse_json(self, data: str) -> ModelT:
+        """Decode a string into a model instance."""
+        obj = self._schema.__config__.json_loads(data)
+        schema_version = obj.pop(SCHEMA_VERSION_KEY, 0)
+
+        for migrate in self._migrations[schema_version:]:
+            obj = migrate(obj)
+
+        return self._schema.parse_obj(obj)
+
+    def _get_key_path(self, key: str) -> PurePath:
+        return PurePosixPath(self._directory / key)
+
+    def _get_item_key(self, item: ModelT, key: Optional[str]) -> str:
+        item_key = (
+            getattr(item, self._primary_key, None)
+            if self._primary_key is not None
+            else key
+        )
+
+        assert item_key is not None, "key or a model with a primary_key required"
+
+        return str(item_key)
+
+    def _maybe_raise_file_error(self, error: FileError) -> None:
+        if not self._ignore_errors:
+            if isinstance(error, FileParseError):
+                raise ItemDecodeError(str(error))
+            elif isinstance(error, FileEncodeError):
+                raise ItemEncodeError(str(error))
+            elif isinstance(error, (FileReadError, FileWriteError, RemoveFileError)):
+                raise ItemAccessError(str(error))

--- a/junk_drawer/read_store.py
+++ b/junk_drawer/read_store.py
@@ -1,7 +1,7 @@
 """Read-only store module for junk_drawer."""
 from __future__ import annotations
 from logging import getLogger
-from pathlib import PurePath, PurePosixPath
+from pathlib import PurePosixPath
 from pydantic import BaseModel
 from typing import (
     Any,
@@ -43,12 +43,12 @@ log = getLogger(__name__)
 
 
 class ReadStore(Generic[ModelT]):
-    """A Store class is used to manage reading a collection of items."""
+    """A ReadStore is used to read items in a collection."""
 
     @classmethod
     def create(
         cls: Type[StoreT],
-        directory: Union[str, PurePath],
+        directory: Union[str, PurePosixPath],
         schema: Type[ModelT],
         *,
         primary_key: Optional[str] = None,
@@ -56,7 +56,7 @@ class ReadStore(Generic[ModelT]):
         ignore_errors: bool = False,
     ) -> StoreT:
         """Create a new ReadStore."""
-        directory = PurePath(directory)
+        directory = PurePosixPath(directory)
         filesystem = AsyncFilesystem.create()
 
         return cls(
@@ -70,7 +70,7 @@ class ReadStore(Generic[ModelT]):
 
     def __init__(
         self,
-        directory: PurePath,
+        directory: PurePosixPath,
         schema: Type[ModelT],
         *,
         primary_key: Optional[str],
@@ -192,7 +192,7 @@ class ReadStore(Generic[ModelT]):
 
         return self._schema.parse_obj(obj)
 
-    def _get_key_path(self, key: str) -> PurePath:
+    def _get_key_path(self, key: str) -> PurePosixPath:
         return PurePosixPath(self._directory / key)
 
     def _get_item_key(self, item: ModelT, key: Optional[str]) -> str:

--- a/junk_drawer/store.py
+++ b/junk_drawer/store.py
@@ -16,7 +16,7 @@ log = getLogger(__name__)
 
 
 class Store(ReadStore[ModelT]):
-    """A Store class is used to create and manage a collection of items."""
+    """A Store is used to create, read, update, and delete items in a collection."""
 
     async def put(self, item: ModelT, key: Optional[str] = None) -> Optional[str]:
         """

--- a/junk_drawer/store.py
+++ b/junk_drawer/store.py
@@ -1,212 +1,22 @@
 """Store module for junk_drawer."""
 from __future__ import annotations
 from logging import getLogger
-from pathlib import PurePath
-from pydantic import BaseModel
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Type,
-    Union,
-)
+from typing import Optional
 
-from .errors import ItemDecodeError, ItemEncodeError, ItemAccessError
+from .read_store import SCHEMA_VERSION_KEY, ReadStore, ModelT
 
 from .filesystem import (
-    AsyncFilesystemLike,
-    AsyncFilesystem,
     PathNotFoundError,
     RemoveFileError,
     FileEncodeError,
-    FileReadError,
-    FileParseError,
     FileWriteError,
-    FileError,
 )
-
-
-SCHEMA_VERSION_KEY = "__schema_version__"
-
-ModelT = TypeVar("ModelT", bound=BaseModel)
-
-Migration = Callable[[Dict[str, Any]], Dict[str, Any]]
 
 log = getLogger(__name__)
 
 
-class Store(Generic[ModelT]):
+class Store(ReadStore[ModelT]):
     """A Store class is used to create and manage a collection of items."""
-
-    @classmethod
-    async def create(
-        cls: Type[Store[ModelT]],
-        directory: Union[str, PurePath],
-        schema: Type[ModelT],
-        *,
-        primary_key: Optional[str] = None,
-        migrations: Sequence[Migration] = (),
-        ignore_errors: bool = False,
-    ) -> Store[ModelT]:
-        """Create a Store, waiting for the directory to be set up if necessary."""
-        directory = PurePath(directory)
-        filesystem = AsyncFilesystem.create()
-
-        await filesystem.ensure_dir(directory)
-
-        return cls(
-            directory=directory,
-            schema=schema,
-            migrations=migrations,
-            primary_key=primary_key,
-            ignore_errors=ignore_errors,
-            filesystem=filesystem,
-        )
-
-    @classmethod
-    def create_sync(
-        cls: Type[Store[ModelT]],
-        directory: Union[str, PurePath],
-        schema: Type[ModelT],
-        *,
-        primary_key: Optional[str] = None,
-        migrations: Sequence[Migration] = (),
-        ignore_errors: bool = False,
-    ) -> Store[ModelT]:
-        """Create a Store, waiting for the directory to be set up synchronously."""
-        directory = PurePath(directory)
-        filesystem = AsyncFilesystem.create()
-
-        filesystem.sync.ensure_dir(directory)
-
-        return cls(
-            directory=directory,
-            schema=schema,
-            migrations=migrations,
-            primary_key=primary_key,
-            ignore_errors=ignore_errors,
-            filesystem=filesystem,
-        )
-
-    def __init__(
-        self,
-        directory: PurePath,
-        schema: Type[ModelT],
-        *,
-        primary_key: Optional[str],
-        migrations: Sequence[Migration],
-        ignore_errors: bool,
-        filesystem: AsyncFilesystemLike,
-    ) -> None:
-        """Initialize a Store; use Store.create instead."""
-        self._directory = directory
-        self._schema = schema
-        self._migrations = migrations
-        self._primary_key = primary_key
-        self._filesystem = filesystem
-        self._ignore_errors = ignore_errors
-
-    async def exists(self, key: str) -> bool:
-        """Check whether a key exists in the store."""
-        key_path = self._get_key_path(key)
-        return await self._filesystem.file_exists(key_path)
-
-    def exists_sync(self, key: str) -> bool:
-        """
-        Check whether a key exists in the store.
-
-        Synchronous version of :py:meth:`exists`.
-        """
-        key_path = self._get_key_path(key)
-        return self._filesystem.sync.file_exists(key_path)
-
-    async def get(self, key: str) -> Optional[ModelT]:
-        """Get an item from the store by key, if that key exists."""
-        key_path = self._get_key_path(key)
-
-        try:
-            return await self._filesystem.read_json(
-                key_path, parse_json=self.parse_json
-            )
-        except (PathNotFoundError, FileParseError, FileReadError) as error:
-            self._maybe_raise_file_error(error)
-            return None
-
-    def get_sync(self, key: str) -> Optional[ModelT]:
-        """
-        Get an item from the store by key, if that key exists.
-
-        Synchronous version of :py:meth:`get`.
-        """
-        key_path = self._get_key_path(key)
-
-        try:
-            return self._filesystem.sync.read_json(key_path, parse_json=self.parse_json)
-        except (PathNotFoundError, FileParseError, FileReadError) as error:
-            self._maybe_raise_file_error(error)
-            return None
-
-    async def get_all_keys(self) -> List[str]:
-        """Get all keys in the store."""
-        return await self._filesystem.read_dir(self._directory)
-
-    def get_all_keys_sync(self) -> List[str]:
-        """
-        Get all keys in the store.
-
-        Synchronous version of :py:meth:`get_all_keys`.
-        """
-        return self._filesystem.sync.read_dir(self._directory)
-
-    async def get_all_entries(self) -> List[Tuple[str, ModelT]]:
-        """Get all key, item entry pairs in the store."""
-        try:
-            dir_entries = await self._filesystem.read_json_dir(
-                self._directory,
-                parse_json=self.parse_json,
-                ignore_errors=self._ignore_errors,
-            )
-        except (PathNotFoundError, FileParseError, FileReadError) as error:
-            self._maybe_raise_file_error(error)
-
-        return [(entry.path.stem, entry.contents) for entry in dir_entries]
-
-    def get_all_entries_sync(self) -> List[Tuple[str, ModelT]]:
-        """
-        Get all key, item entry pairs in the store.
-
-        Synchronous version of :py:meth:`get_all_entries`.
-        """
-        try:
-            dir_entries = self._filesystem.sync.read_json_dir(
-                self._directory,
-                parse_json=self.parse_json,
-                ignore_errors=self._ignore_errors,
-            )
-        except (PathNotFoundError, FileParseError, FileReadError) as error:
-            self._maybe_raise_file_error(error)
-
-        return [(entry.path.stem, entry.contents) for entry in dir_entries]
-
-    async def get_all_items(self) -> List[ModelT]:
-        """Get all items in the store."""
-        entries = await self.get_all_entries()
-        return [item for key, item in entries]
-
-    def get_all_items_sync(self) -> List[ModelT]:
-        """
-        Get all items in the store.
-
-        Synchronous version of :py:meth:`get_all_items`.
-        """
-        entries = self.get_all_entries_sync()
-        return [item for key, item in entries]
 
     async def put(self, item: ModelT, key: Optional[str] = None) -> Optional[str]:
         """
@@ -344,26 +154,3 @@ class Store(Generic[ModelT]):
             obj = migrate(obj)
 
         return self._schema.parse_obj(obj)
-
-    def _get_key_path(self, key: str) -> PurePath:
-        return self._directory / key
-
-    def _get_item_key(self, item: ModelT, key: Optional[str]) -> str:
-        item_key = (
-            getattr(item, self._primary_key, None)
-            if self._primary_key is not None
-            else key
-        )
-
-        assert item_key is not None, "key or a model with a primary_key required"
-
-        return str(item_key)
-
-    def _maybe_raise_file_error(self, error: FileError) -> None:
-        if not self._ignore_errors:
-            if isinstance(error, FileParseError):
-                raise ItemDecodeError(str(error))
-            elif isinstance(error, FileEncodeError):
-                raise ItemEncodeError(str(error))
-            elif isinstance(error, (FileReadError, FileWriteError, RemoveFileError)):
-                raise ItemAccessError(str(error))

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,41 +1,48 @@
 [[package]]
+name = "apipkg"
+version = "1.5"
+description = "apipkg: namespace control and lazy-import mechanism"
 category = "dev"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.4.4"
 
 [[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.0"
 
 [[package]]
-category = "dev"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.2.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-category = "dev"
-description = "The uncompromising code formatter."
 name = "black"
+version = "20.8b1"
+description = "The uncompromising code formatter."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "20.8b1"
 
 [package.dependencies]
 appdirs = "*"
@@ -52,125 +59,133 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-category = "dev"
-description = "Composable command line interface toolkit"
 name = "click"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "7.1.2"
-
-[[package]]
+description = "Composable command line interface toolkit"
 category = "dev"
-description = "Cross-platform colored terminal text."
-name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
 
 [[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
 category = "dev"
-description = "Pythonic argument parser, that will make you smile"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "docopt"
+version = "0.6.2"
+description = "Pythonic argument parser, that will make you smile"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.6.2"
 
 [[package]]
+name = "execnet"
+version = "1.7.1"
+description = "execnet: rapid multi-Python deployment"
 category = "dev"
-description = "the modular source code checker: pep8 pyflakes and co"
-name = "flake8"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
+apipkg = ">=1.4"
+
+[package.extras]
+testing = ["pre-commit"]
+
+[[package]]
+name = "flake8"
+version = "3.8.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
 [[package]]
-category = "dev"
-description = "Flake8 Type Annotation Checks"
 name = "flake8-annotations"
+version = "2.5.0"
+description = "Flake8 Type Annotation Checks"
+category = "dev"
 optional = false
 python-versions = ">=3.6.1,<4.0.0"
-version = "2.4.1"
 
 [package.dependencies]
 flake8 = ">=3.7,<3.9"
-
-[package.dependencies.typed-ast]
-python = "<3.8"
-version = ">=1.4,<2.0"
+typed-ast = {version = ">=1.4,<2.0", markers = "python_version < \"3.8\""}
 
 [[package]]
-category = "dev"
-description = "Extension for flake8 which uses pydocstyle to check docstrings"
 name = "flake8-docstrings"
+version = "1.5.0"
+description = "Extension for flake8 which uses pydocstyle to check docstrings"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.5.0"
 
 [package.dependencies]
 flake8 = ">=3"
 pydocstyle = ">=2.1"
 
 [[package]]
-category = "dev"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
 name = "importlib-metadata"
+version = "3.4.0"
+description = "Read metadata from Python packages"
+category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "2.0.0"
+python-versions = ">=3.6"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "dev"
-description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.0.1"
 
 [[package]]
-category = "dev"
-description = "McCabe checker, plugin for flake8"
 name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.6.1"
 
 [[package]]
-category = "dev"
-description = "Rolling backport of unittest.mock for all Pythons"
 name = "mock"
+version = "4.0.3"
+description = "Rolling backport of unittest.mock for all Pythons"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "4.0.2"
 
 [package.extras]
 build = ["twine", "wheel", "blurb"]
 docs = ["sphinx"]
-test = ["pytest", "pytest-cov"]
+test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
-category = "dev"
-description = "Optional static typing for Python"
 name = "mypy"
+version = "0.782"
+description = "Optional static typing for Python"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "0.782"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -181,80 +196,69 @@ typing-extensions = ">=3.7.4"
 dmypy = ["psutil (>=4.0)"]
 
 [[package]]
-category = "dev"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
 name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.4.3"
 
 [[package]]
-category = "dev"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.8"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
-six = "*"
 
 [[package]]
-category = "dev"
-description = "Utility library for gitignore style pattern matching of file paths."
 name = "pathspec"
+version = "0.8.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.8.0"
 
 [[package]]
-category = "dev"
-description = "File system general utilities"
-name = "pathtools"
-optional = false
-python-versions = "*"
-version = "0.1.2"
-
-[[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.9.0"
-
-[[package]]
+version = "1.10.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
-description = "Python style guide checker"
-name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.6.0"
 
 [[package]]
-category = "main"
-description = "Data validation and settings management using python 3.6 type hinting"
+name = "pycodestyle"
+version = "2.6.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pydantic"
+version = "1.7.3"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "1.6.1"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -262,65 +266,61 @@ email = ["email-validator (>=1.0.3)"]
 typing_extensions = ["typing-extensions (>=3.7.2)"]
 
 [[package]]
-category = "dev"
-description = "Python docstring style checker"
 name = "pydocstyle"
+version = "5.1.1"
+description = "Python docstring style checker"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "5.1.1"
 
 [package.dependencies]
 snowballstemmer = "*"
 
 [[package]]
-category = "dev"
-description = "passive checker of Python programs"
 name = "pyflakes"
+version = "2.2.0"
+description = "passive checker of Python programs"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.2.0"
 
 [[package]]
-category = "dev"
-description = "Python parsing module"
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "6.2.2"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
 optional = false
-python-versions = ">=3.5"
-version = "6.1.1"
+python-versions = ">=3.6"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
-attrs = ">=17.4.0"
-colorama = "*"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0"
+pluggy = ">=0.12,<1.0.0a1"
 py = ">=1.8.2"
 toml = "*"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
 [package.extras]
-checkqa_mypy = ["mypy (0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "dev"
-description = "Pytest support for asyncio."
 name = "pytest-asyncio"
+version = "0.14.0"
+description = "Pytest support for asyncio."
+category = "dev"
 optional = false
 python-versions = ">= 3.5"
-version = "0.14.0"
 
 [package.dependencies]
 pytest = ">=5.4.0"
@@ -329,12 +329,24 @@ pytest = ">=5.4.0"
 testing = ["async-generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-forked"
+version = "1.3.0"
+description = "run tests in isolated forked subprocesses"
 category = "dev"
-description = "Local continuous test runner with pytest and watchdog."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+py = "*"
+pytest = ">=3.10"
+
+[[package]]
 name = "pytest-watch"
+version = "4.2.0"
+description = "Local continuous test runner with pytest and watchdog."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "4.2.0"
 
 [package.dependencies]
 colorama = ">=0.3.3"
@@ -343,86 +355,95 @@ pytest = ">=2.6.4"
 watchdog = ">=0.6.0"
 
 [[package]]
+name = "pytest-xdist"
+version = "2.2.0"
+description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
 category = "dev"
-description = "Alternative regular expression module, to replace re."
-name = "regex"
 optional = false
-python-versions = "*"
-version = "2020.9.27"
-
-[[package]]
-category = "dev"
-description = "Python 2 and 3 compatibility utilities"
-name = "six"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
-
-[[package]]
-category = "dev"
-description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
-name = "snowballstemmer"
-optional = false
-python-versions = "*"
-version = "2.0.0"
-
-[[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
-name = "toml"
-optional = false
-python-versions = "*"
-version = "0.10.1"
-
-[[package]]
-category = "dev"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-name = "typed-ast"
-optional = false
-python-versions = "*"
-version = "1.4.1"
-
-[[package]]
-category = "dev"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-name = "typing-extensions"
-optional = false
-python-versions = "*"
-version = "3.7.4.3"
-
-[[package]]
-category = "dev"
-description = "Filesystem events monitoring"
-name = "watchdog"
-optional = false
-python-versions = "*"
-version = "0.10.3"
+python-versions = ">=3.5"
 
 [package.dependencies]
-pathtools = ">=0.1.1"
+execnet = ">=1.1"
+pytest = ">=6.0.0"
+pytest-forked = "*"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+testing = ["filelock"]
+
+[[package]]
+name = "regex"
+version = "2020.11.13"
+description = "Alternative regular expression module, to replace re."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "snowballstemmer"
+version = "2.1.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "typed-ast"
+version = "1.4.2"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "watchdog"
+version = "1.0.2"
+description = "Filesystem events monitoring"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)", "argh (>=0.24.1)"]
 
 [[package]]
-category = "dev"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
 name = "zipp"
+version = "3.4.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.3.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "6c7f77531f45972f06f3a3872f570bd15eadba7d0490bbd4120bdf7b9c731b31"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "^3.7"
+content-hash = "60903b279101289b54651137346268e10a39c7b9356a9d568c65e35e369045f6"
 
 [metadata.files]
+apipkg = [
+    {file = "apipkg-1.5-py2.py3-none-any.whl", hash = "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"},
+    {file = "apipkg-1.5.tar.gz", hash = "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6"},
+]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
@@ -432,8 +453,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
-    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
@@ -443,39 +464,43 @@ click = [
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
+]
+execnet = [
+    {file = "execnet-1.7.1-py2.py3-none-any.whl", hash = "sha256:d4efd397930c46415f62f8a31388d6be4f27a91d7550eb79bc64a756e0056547"},
+    {file = "execnet-1.7.1.tar.gz", hash = "sha256:cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50"},
 ]
 flake8 = [
     {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 flake8-annotations = [
-    {file = "flake8-annotations-2.4.1.tar.gz", hash = "sha256:0bcebb0792f1f96d617ded674dca7bf64181870bfe5dace353a1483551f8e5f1"},
-    {file = "flake8_annotations-2.4.1-py3-none-any.whl", hash = "sha256:bebd11a850f6987a943ce8cdff4159767e0f5f89b3c88aca64680c2175ee02df"},
+    {file = "flake8-annotations-2.5.0.tar.gz", hash = "sha256:e17947a48a5b9f632fe0c72682fc797c385e451048e7dfb20139f448a074cb3e"},
+    {file = "flake8_annotations-2.5.0-py3-none-any.whl", hash = "sha256:3a377140556aecf11fa9f3bb18c10db01f5ea56dc79a730e2ec9b4f1f49e2055"},
 ]
 flake8-docstrings = [
     {file = "flake8-docstrings-1.5.0.tar.gz", hash = "sha256:3d5a31c7ec6b7367ea6506a87ec293b94a0a46c0bce2bb4975b7f1d09b6f3717"},
     {file = "flake8_docstrings-1.5.0-py2.py3-none-any.whl", hash = "sha256:a256ba91bc52307bef1de59e2a009c3cf61c3d0952dbe035d6ff7208940c2edc"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-2.0.0-py2.py3-none-any.whl", hash = "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"},
-    {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
+    {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},
+    {file = "importlib_metadata-3.4.0.tar.gz", hash = "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"},
 ]
 iniconfig = [
-    {file = "iniconfig-1.0.1-py3-none-any.whl", hash = "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437"},
-    {file = "iniconfig-1.0.1.tar.gz", hash = "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"},
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mock = [
-    {file = "mock-4.0.2-py3-none-any.whl", hash = "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0"},
-    {file = "mock-4.0.2.tar.gz", hash = "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"},
+    {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
+    {file = "mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"},
 ]
 mypy = [
     {file = "mypy-0.782-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c"},
@@ -498,46 +523,48 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
-    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
-    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+    {file = "packaging-20.8-py2.py3-none-any.whl", hash = "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858"},
+    {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
 ]
 pathspec = [
-    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
-    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
-]
-pathtools = [
-    {file = "pathtools-0.1.2.tar.gz", hash = "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"},
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 py = [
-    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
-    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
     {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
 ]
 pydantic = [
-    {file = "pydantic-1.6.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:418b84654b60e44c0cdd5384294b0e4bc1ebf42d6e873819424f3b78b8690614"},
-    {file = "pydantic-1.6.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4900b8820b687c9a3ed753684337979574df20e6ebe4227381d04b3c3c628f99"},
-    {file = "pydantic-1.6.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:b49c86aecde15cde33835d5d6360e55f5e0067bb7143a8303bf03b872935c75b"},
-    {file = "pydantic-1.6.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2de562a456c4ecdc80cf1a8c3e70c666625f7d02d89a6174ecf63754c734592e"},
-    {file = "pydantic-1.6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f769141ab0abfadf3305d4fcf36660e5cf568a666dd3efab7c3d4782f70946b1"},
-    {file = "pydantic-1.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2dc946b07cf24bee4737ced0ae77e2ea6bc97489ba5a035b603bd1b40ad81f7e"},
-    {file = "pydantic-1.6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:36dbf6f1be212ab37b5fda07667461a9219c956181aa5570a00edfb0acdfe4a1"},
-    {file = "pydantic-1.6.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:1783c1d927f9e1366e0e0609ae324039b2479a1a282a98ed6a6836c9ed02002c"},
-    {file = "pydantic-1.6.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:cf3933c98cb5e808b62fae509f74f209730b180b1e3c3954ee3f7949e083a7df"},
-    {file = "pydantic-1.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f8af9b840a9074e08c0e6dc93101de84ba95df89b267bf7151d74c553d66833b"},
-    {file = "pydantic-1.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:40d765fa2d31d5be8e29c1794657ad46f5ee583a565c83cea56630d3ae5878b9"},
-    {file = "pydantic-1.6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3fa799f3cfff3e5f536cbd389368fc96a44bb30308f258c94ee76b73bd60531d"},
-    {file = "pydantic-1.6.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:6c3f162ba175678218629f446a947e3356415b6b09122dcb364e58c442c645a7"},
-    {file = "pydantic-1.6.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:eb75dc1809875d5738df14b6566ccf9fd9c0bcde4f36b72870f318f16b9f5c20"},
-    {file = "pydantic-1.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:530d7222a2786a97bc59ee0e0ebbe23728f82974b1f1ad9a11cd966143410633"},
-    {file = "pydantic-1.6.1-py36.py37.py38-none-any.whl", hash = "sha256:b5b3489cb303d0f41ad4a7390cf606a5f2c7a94dcba20c051cd1c653694cb14d"},
-    {file = "pydantic-1.6.1.tar.gz", hash = "sha256:54122a8ed6b75fe1dd80797f8251ad2063ea348a03b77218d73ea9fe19bd4e73"},
+    {file = "pydantic-1.7.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c59ea046aea25be14dc22d69c97bee629e6d48d2b2ecb724d7fe8806bf5f61cd"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a4143c8d0c456a093387b96e0f5ee941a950992904d88bc816b4f0e72c9a0009"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:d8df4b9090b595511906fa48deda47af04e7d092318bfb291f4d45dfb6bb2127"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:514b473d264671a5c672dfb28bdfe1bf1afd390f6b206aa2ec9fed7fc592c48e"},
+    {file = "pydantic-1.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:dba5c1f0a3aeea5083e75db9660935da90216f8a81b6d68e67f54e135ed5eb23"},
+    {file = "pydantic-1.7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:59e45f3b694b05a69032a0d603c32d453a23f0de80844fb14d55ab0c6c78ff2f"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5b24e8a572e4b4c18f614004dda8c9f2c07328cb5b6e314d6e1bbd536cb1a6c1"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:b2b054d095b6431cdda2f852a6d2f0fdec77686b305c57961b4c5dd6d863bf3c"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:025bf13ce27990acc059d0c5be46f416fc9b293f45363b3d19855165fee1874f"},
+    {file = "pydantic-1.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:6e3874aa7e8babd37b40c4504e3a94cc2023696ced5a0500949f3347664ff8e2"},
+    {file = "pydantic-1.7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e682f6442ebe4e50cb5e1cfde7dda6766fb586631c3e5569f6aa1951fd1a76ef"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:185e18134bec5ef43351149fe34fda4758e53d05bb8ea4d5928f0720997b79ef"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:f5b06f5099e163295b8ff5b1b71132ecf5866cc6e7f586d78d7d3fd6e8084608"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:24ca47365be2a5a3cc3f4a26dcc755bcdc9f0036f55dcedbd55663662ba145ec"},
+    {file = "pydantic-1.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:d1fe3f0df8ac0f3a9792666c69a7cd70530f329036426d06b4f899c025aca74e"},
+    {file = "pydantic-1.7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f6864844b039805add62ebe8a8c676286340ba0c6d043ae5dea24114b82a319e"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ecb54491f98544c12c66ff3d15e701612fc388161fd455242447083350904730"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:ffd180ebd5dd2a9ac0da4e8b995c9c99e7c74c31f985ba090ee01d681b1c4b95"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8d72e814c7821125b16f1553124d12faba88e85405b0864328899aceaad7282b"},
+    {file = "pydantic-1.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:475f2fa134cf272d6631072554f845d0630907fce053926ff634cc6bc45bf1af"},
+    {file = "pydantic-1.7.3-py3-none-any.whl", hash = "sha256:38be427ea01a78206bcaf9a56f835784afcba9e5b88fbdce33bbbfbcd7841229"},
+    {file = "pydantic-1.7.3.tar.gz", hash = "sha256:213125b7e9e64713d16d988d10997dabc6a1f73f3991e1ff8e35ebb1409c7dc9"},
 ]
 pydocstyle = [
     {file = "pydocstyle-5.1.1-py3-none-any.whl", hash = "sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678"},
@@ -552,73 +579,106 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.1.1-py3-none-any.whl", hash = "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9"},
-    {file = "pytest-6.1.1.tar.gz", hash = "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"},
+    {file = "pytest-6.2.2-py3-none-any.whl", hash = "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"},
+    {file = "pytest-6.2.2.tar.gz", hash = "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9"},
 ]
 pytest-asyncio = [
     {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
     {file = "pytest_asyncio-0.14.0-py3-none-any.whl", hash = "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d"},
 ]
+pytest-forked = [
+    {file = "pytest-forked-1.3.0.tar.gz", hash = "sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca"},
+    {file = "pytest_forked-1.3.0-py2.py3-none-any.whl", hash = "sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815"},
+]
 pytest-watch = [
     {file = "pytest-watch-4.2.0.tar.gz", hash = "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9"},
 ]
-regex = [
-    {file = "regex-2020.9.27-cp27-cp27m-win32.whl", hash = "sha256:d23a18037313714fb3bb5a94434d3151ee4300bae631894b1ac08111abeaa4a3"},
-    {file = "regex-2020.9.27-cp27-cp27m-win_amd64.whl", hash = "sha256:84e9407db1b2eb368b7ecc283121b5e592c9aaedbe8c78b1a2f1102eb2e21d19"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5f18875ac23d9aa2f060838e8b79093e8bb2313dbaaa9f54c6d8e52a5df097be"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ae91972f8ac958039920ef6e8769277c084971a142ce2b660691793ae44aae6b"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9a02d0ae31d35e1ec12a4ea4d4cca990800f66a917d0fb997b20fbc13f5321fc"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ebbe29186a3d9b0c591e71b7393f1ae08c83cb2d8e517d2a822b8f7ec99dfd8b"},
-    {file = "regex-2020.9.27-cp36-cp36m-win32.whl", hash = "sha256:4707f3695b34335afdfb09be3802c87fa0bc27030471dbc082f815f23688bc63"},
-    {file = "regex-2020.9.27-cp36-cp36m-win_amd64.whl", hash = "sha256:9bc13e0d20b97ffb07821aa3e113f9998e84994fe4d159ffa3d3a9d1b805043b"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f1b3afc574a3db3b25c89161059d857bd4909a1269b0b3cb3c904677c8c4a3f7"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5533a959a1748a5c042a6da71fe9267a908e21eded7a4f373efd23a2cbdb0ecc"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:1fe0a41437bbd06063aa184c34804efa886bcc128222e9916310c92cd54c3b4c"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:c570f6fa14b9c4c8a4924aaad354652366577b4f98213cf76305067144f7b100"},
-    {file = "regex-2020.9.27-cp37-cp37m-win32.whl", hash = "sha256:eda4771e0ace7f67f58bc5b560e27fb20f32a148cbc993b0c3835970935c2707"},
-    {file = "regex-2020.9.27-cp37-cp37m-win_amd64.whl", hash = "sha256:60b0e9e6dc45683e569ec37c55ac20c582973841927a85f2d8a7d20ee80216ab"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux1_i686.whl", hash = "sha256:088afc8c63e7bd187a3c70a94b9e50ab3f17e1d3f52a32750b5b77dbe99ef5ef"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:eaf548d117b6737df379fdd53bdde4f08870e66d7ea653e230477f071f861121"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:41bb65f54bba392643557e617316d0d899ed5b4946dccee1cb6696152b29844b"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8d69cef61fa50c8133382e61fd97439de1ae623fe943578e477e76a9d9471637"},
-    {file = "regex-2020.9.27-cp38-cp38-win32.whl", hash = "sha256:f2388013e68e750eaa16ccbea62d4130180c26abb1d8e5d584b9baf69672b30f"},
-    {file = "regex-2020.9.27-cp38-cp38-win_amd64.whl", hash = "sha256:4318d56bccfe7d43e5addb272406ade7a2274da4b70eb15922a071c58ab0108c"},
-    {file = "regex-2020.9.27.tar.gz", hash = "sha256:a6f32aea4260dfe0e55dc9733ea162ea38f0ea86aa7d0f77b15beac5bf7b369d"},
+pytest-xdist = [
+    {file = "pytest-xdist-2.2.0.tar.gz", hash = "sha256:1d8edbb1a45e8e1f8e44b1260583107fc23f8bc8da6d18cb331ff61d41258ecf"},
+    {file = "pytest_xdist-2.2.0-py3-none-any.whl", hash = "sha256:f127e11e84ad37cc1de1088cb2990f3c354630d428af3f71282de589c5bb779b"},
 ]
-six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+regex = [
+    {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6e4b08c6f8daca7d8f07c8d24e4331ae7953333dbd09c648ed6ebd24db5a10ee"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bba349276b126947b014e50ab3316c027cac1495992f10e5682dc677b3dfa0c5"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:56e01daca75eae420bce184edd8bb341c8eebb19dd3bce7266332258f9fb9dd7"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:6a8ce43923c518c24a2579fda49f093f1397dad5d18346211e46f134fc624e31"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab79fcb02b930de09c76d024d279686ec5d532eb814fd0ed1e0051eb8bd2daa"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:9801c4c1d9ae6a70aeb2128e5b4b68c45d4f0af0d1535500884d644fa9b768c6"},
+    {file = "regex-2020.11.13-cp36-cp36m-win32.whl", hash = "sha256:49cae022fa13f09be91b2c880e58e14b6da5d10639ed45ca69b85faf039f7a4e"},
+    {file = "regex-2020.11.13-cp36-cp36m-win_amd64.whl", hash = "sha256:749078d1eb89484db5f34b4012092ad14b327944ee7f1c4f74d6279a6e4d1884"},
+    {file = "regex-2020.11.13-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b2f4007bff007c96a173e24dcda236e5e83bde4358a557f9ccf5e014439eae4b"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:38c8fd190db64f513fe4e1baa59fed086ae71fa45083b6936b52d34df8f86a88"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5862975b45d451b6db51c2e654990c1820523a5b07100fc6903e9c86575202a0"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:262c6825b309e6485ec2493ffc7e62a13cf13fb2a8b6d212f72bd53ad34118f1"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bafb01b4688833e099d79e7efd23f99172f501a15c44f21ea2118681473fdba0"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e32f5f3d1b1c663af7f9c4c1e72e6ffe9a78c03a31e149259f531e0fed826512"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3bddc701bdd1efa0d5264d2649588cbfda549b2899dc8d50417e47a82e1387ba"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538"},
+    {file = "regex-2020.11.13-cp37-cp37m-win32.whl", hash = "sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4"},
+    {file = "regex-2020.11.13-cp37-cp37m-win_amd64.whl", hash = "sha256:1fa7ee9c2a0e30405e21031d07d7ba8617bc590d391adfc2b7f1e8b99f46f444"},
+    {file = "regex-2020.11.13-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:baf378ba6151f6e272824b86a774326f692bc2ef4cc5ce8d5bc76e38c813a55f"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e3faaf10a0d1e8e23a9b51d1900b72e1635c2d5b0e1bea1c18022486a8e2e52d"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2a11a3e90bd9901d70a5b31d7dd85114755a581a5da3fc996abfefa48aee78af"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1ebb090a426db66dd80df8ca85adc4abfcbad8a7c2e9a5ec7513ede522e0a8f"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b2b1a5ddae3677d89b686e5c625fc5547c6e492bd755b520de5332773a8af06b"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2c99e97d388cd0a8d30f7c514d67887d8021541b875baf09791a3baad48bb4f8"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:c084582d4215593f2f1d28b65d2a2f3aceff8342aa85afd7be23a9cad74a0de5"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a3d748383762e56337c39ab35c6ed4deb88df5326f97a38946ddd19028ecce6b"},
+    {file = "regex-2020.11.13-cp38-cp38-win32.whl", hash = "sha256:7913bd25f4ab274ba37bc97ad0e21c31004224ccb02765ad984eef43e04acc6c"},
+    {file = "regex-2020.11.13-cp38-cp38-win_amd64.whl", hash = "sha256:6c54ce4b5d61a7129bad5c5dc279e222afd00e721bf92f9ef09e4fae28755683"},
+    {file = "regex-2020.11.13-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1862a9d9194fae76a7aaf0150d5f2a8ec1da89e8b55890b1786b8f88a0f619dc"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4902e6aa086cbb224241adbc2f06235927d5cdacffb2425c73e6570e8d862364"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7a25fcbeae08f96a754b45bdc050e1fb94b95cab046bf56b016c25e9ab127b3e"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:d2d8ce12b7c12c87e41123997ebaf1a5767a5be3ec545f64675388970f415e2e"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f7d29a6fc4760300f86ae329e3b6ca28ea9c20823df123a2ea8693e967b29917"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:717881211f46de3ab130b58ec0908267961fadc06e44f974466d1887f865bd5b"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3128e30d83f2e70b0bed9b2a34e92707d0877e460b402faca908c6667092ada9"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8f6a2229e8ad946e36815f2a03386bb8353d4bde368fdf8ca5f0cb97264d3b5c"},
+    {file = "regex-2020.11.13-cp39-cp39-win32.whl", hash = "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"},
+    {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
+    {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
 ]
 snowballstemmer = [
-    {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
-    {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
+    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
+    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 toml = [
-    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
-    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
-    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
-    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
+    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
+    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
+    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
@@ -626,9 +686,25 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 watchdog = [
-    {file = "watchdog-0.10.3.tar.gz", hash = "sha256:4214e1379d128b0588021880ccaf40317ee156d4603ac388b9adcf29165e0c04"},
+    {file = "watchdog-1.0.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e2a531e71be7b5cc3499ae2d1494d51b6a26684bcc7c3146f63c810c00e8a3cc"},
+    {file = "watchdog-1.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e7c73edef48f4ceeebb987317a67e0080e5c9228601ff67b3c4062fa020403c7"},
+    {file = "watchdog-1.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:85e6574395aa6c1e14e0f030d9d7f35c2340a6cf95d5671354ce876ac3ffdd4d"},
+    {file = "watchdog-1.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:27d9b4666938d5d40afdcdf2c751781e9ce36320788b70208d0f87f7401caf93"},
+    {file = "watchdog-1.0.2-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2f1ade0d0802503fda4340374d333408831cff23da66d7e711e279ba50fe6c4a"},
+    {file = "watchdog-1.0.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f1d0e878fd69129d0d68b87cee5d9543f20d8018e82998efb79f7e412d42154a"},
+    {file = "watchdog-1.0.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d948ad9ab9aba705f9836625b32e965b9ae607284811cd98334423f659ea537a"},
+    {file = "watchdog-1.0.2-py3-none-manylinux2014_armv7l.whl", hash = "sha256:101532b8db506559e52a9b5d75a308729b3f68264d930670e6155c976d0e52a0"},
+    {file = "watchdog-1.0.2-py3-none-manylinux2014_i686.whl", hash = "sha256:b1d723852ce90a14abf0ec0ca9e80689d9509ee4c9ee27163118d87b564a12ac"},
+    {file = "watchdog-1.0.2-py3-none-manylinux2014_ppc64.whl", hash = "sha256:68744de2003a5ea2dfbb104f9a74192cf381334a9e2c0ed2bbe1581828d50b61"},
+    {file = "watchdog-1.0.2-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:602dbd9498592eacc42e0632c19781c3df1728ef9cbab555fab6778effc29eeb"},
+    {file = "watchdog-1.0.2-py3-none-manylinux2014_s390x.whl", hash = "sha256:016b01495b9c55b5d4126ed8ae75d93ea0d99377084107c33162df52887cee18"},
+    {file = "watchdog-1.0.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:5f1f3b65142175366ba94c64d8d4c8f4015825e0beaacee1c301823266b47b9b"},
+    {file = "watchdog-1.0.2-py3-none-win32.whl", hash = "sha256:57f05e55aa603c3b053eed7e679f0a83873c540255b88d58c6223c7493833bac"},
+    {file = "watchdog-1.0.2-py3-none-win_amd64.whl", hash = "sha256:f84146f7864339c8addf2c2b9903271df21d18d2c721e9a77f779493234a82b5"},
+    {file = "watchdog-1.0.2-py3-none-win_ia64.whl", hash = "sha256:ee21aeebe6b3e51e4ba64564c94cee8dbe7438b9cb60f0bb350c4fa70d1b52c2"},
+    {file = "watchdog-1.0.2.tar.gz", hash = "sha256:376cbc2a35c0392b0fe7ff16fbc1b303fd99d4dd9911ab5581ee9d69adc88982"},
 ]
 zipp = [
-    {file = "zipp-3.3.0-py3-none-any.whl", hash = "sha256:eed8ec0b8d1416b2ca33516a37a08892442f3954dee131e92cfd92d8fe3e7066"},
-    {file = "zipp-3.3.0.tar.gz", hash = "sha256:64ad89efee774d1897a58607895d80789c59778ea02185dd846ac38394a8642b"},
+    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
+    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ flake8-docstrings = "^1.5.0"
 mock = "^4.0.2"
 mypy = "^0.782"
 pytest = "^6.1.0"
-pytest-watch = "^4.2.0"
 pytest-asyncio = "^0.14.0"
+pytest-xdist = "^2.2.0"
 flake8-annotations = "^2.4.1"
 
 [tool.black]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Global test configuration."""
 import pytest
-from pathlib import Path, PurePath
+from pathlib import Path, PurePosixPath
 from junk_drawer import Store
 from junk_drawer.filesystem import SyncFilesystem, AsyncFilesystem
 from .helpers import CoolModel
@@ -43,19 +43,19 @@ def mock_encode_json() -> MagicMock:
 
 
 @pytest.fixture
-def store_path() -> PurePath:
+def store_path() -> PurePosixPath:
     """Store fixture directory path."""
-    return PurePath(STORE_PATH_STR)
+    return PurePosixPath(STORE_PATH_STR)
 
 
 @pytest.fixture
-def real_store_path(tmp_path: Path) -> PurePath:
+def real_store_path(tmp_path: Path) -> PurePosixPath:
     """Actual Store directory path."""
-    return PurePath(tmp_path) / STORE_PATH_STR
+    return PurePosixPath(tmp_path) / STORE_PATH_STR
 
 
 @pytest.fixture
-def store(store_path: PurePath, mock_filesystem: AsyncMock) -> Store[CoolModel]:
+def store(store_path: PurePosixPath, mock_filesystem: AsyncMock) -> Store[CoolModel]:
     """Create a fresh Store with a mock filesystem."""
     return Store(
         directory=store_path,
@@ -68,7 +68,9 @@ def store(store_path: PurePath, mock_filesystem: AsyncMock) -> Store[CoolModel]:
 
 
 @pytest.fixture
-def keyed_store(store_path: PurePath, mock_filesystem: AsyncMock) -> Store[CoolModel]:
+def keyed_store(
+    store_path: PurePosixPath, mock_filesystem: AsyncMock
+) -> Store[CoolModel]:
     """Create a Store with a primary key mock filesystem."""
     return Store(
         directory=store_path,
@@ -82,7 +84,7 @@ def keyed_store(store_path: PurePath, mock_filesystem: AsyncMock) -> Store[CoolM
 
 @pytest.fixture
 def ignore_errors_store(
-    store_path: PurePath, mock_filesystem: AsyncMock
+    store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> Store[CoolModel]:
     """Create a Store with errors ignored."""
     return Store(

--- a/tests/filesystem/test_async_filesystem_reads.py
+++ b/tests/filesystem/test_async_filesystem_reads.py
@@ -154,6 +154,27 @@ async def test_read_json_dir_reads_multiple_files(
     assert Entry(path=path / "baz", contents={"foo": "other side", "bar": 2}) in files
 
 
+async def test_read_json_dir_reads_multiple_files_nested(
+    tmp_path: Path, filesystem: AsyncFilesystem
+) -> None:
+    """It should read a all nested files in a directory."""
+    Path(tmp_path / "some-dir").mkdir()
+    Path(tmp_path / "some-dir" / "foo.json").write_text(
+        """{ "foo": "hello", "bar": 0 }"""
+    )
+    Path(tmp_path / "bar.json").write_text("""{ "foo": "from the", "bar": 1 }""")
+
+    path = PurePath(tmp_path)
+    files: List[Entry[ParsedObj]] = await filesystem.read_json_dir(path)
+
+    assert len(files) == 2
+    assert (
+        Entry(path=path / "some-dir" / "foo", contents={"foo": "hello", "bar": 0})
+        in files
+    )
+    assert Entry(path=path / "bar", contents={"foo": "from the", "bar": 1}) in files
+
+
 async def test_read_json_dir_can_ignore_errors(
     tmp_path: Path, filesystem: AsyncFilesystem
 ) -> None:

--- a/tests/filesystem/test_sync_filesystem_writes.py
+++ b/tests/filesystem/test_sync_filesystem_writes.py
@@ -62,6 +62,16 @@ def test_write_json_encodes_and_writes_obj(
     assert path.with_suffix(".json").read_text() == """{"foo": "hello", "bar": 0}"""
 
 
+def test_write_json_creates_dirs_if_necessary(
+    tmp_path: Path, sync_filesystem: SyncFilesystem
+) -> None:
+    """It should create directories as necessary to reach the path."""
+    path = tmp_path / "foo" / "bar" / "baz"
+    sync_filesystem.write_json(path, {"foo": "hello", "bar": 0})
+
+    assert path.with_suffix(".json").read_text() == """{"foo": "hello", "bar": 0}"""
+
+
 def test_write_json_raises_encode_error(
     tmp_path: Path, sync_filesystem: SyncFilesystem
 ) -> None:

--- a/tests/test_junk_drawer.py
+++ b/tests/test_junk_drawer.py
@@ -1,6 +1,6 @@
 """Entrypoint and end-to-end tests for junk_drawer."""
 import pytest
-from pathlib import Path, PurePath
+from pathlib import Path, PurePosixPath
 from pydantic import BaseModel
 from junk_drawer import Store
 from typing import Optional
@@ -22,7 +22,7 @@ class OldModel(BaseModel):
     foo: str
 
 
-async def test_store_write_and_read(real_store_path: PurePath) -> None:
+async def test_store_write_and_read(real_store_path: PurePosixPath) -> None:
     """A store should be able to write and read a file."""
     store = Store.create(real_store_path, schema=CoolModel)
     item = CoolModel(foo="hello", bar="world")
@@ -36,7 +36,7 @@ async def test_store_write_and_read(real_store_path: PurePath) -> None:
     assert result == CoolModel(foo="hello", bar="world")
 
 
-async def test_store_write_and_read_dir(real_store_path: PurePath) -> None:
+async def test_store_write_and_read_dir(real_store_path: PurePosixPath) -> None:
     """A store should be able to write and read the whole store."""
     store = Store.create(real_store_path, schema=CoolModel)
 
@@ -51,7 +51,7 @@ async def test_store_write_and_read_dir(real_store_path: PurePath) -> None:
     assert ("bar", CoolModel(foo="oh", bar="hai")) in result
 
 
-async def test_store_write_and_ensure(real_store_path: PurePath) -> None:
+async def test_store_write_and_ensure(real_store_path: PurePosixPath) -> None:
     """A store should be able to write and read a file."""
     store = Store.create(real_store_path, schema=CoolModel)
     default_item = CoolModel(foo="default", bar="value")
@@ -66,7 +66,7 @@ async def test_store_write_and_ensure(real_store_path: PurePath) -> None:
     assert result == item
 
 
-async def test_keyed_store_write_and_read(real_store_path: PurePath) -> None:
+async def test_keyed_store_write_and_read(real_store_path: PurePosixPath) -> None:
     """A store should be able to write and read a file."""
     store = Store.create(real_store_path, schema=CoolModel, primary_key="foo")
     item = CoolModel(foo="hello", bar="world")
@@ -80,7 +80,7 @@ async def test_keyed_store_write_and_read(real_store_path: PurePath) -> None:
     assert result == CoolModel(foo="hello", bar="world")
 
 
-async def test_keyed_store_write_and_read_dir(real_store_path: PurePath) -> None:
+async def test_keyed_store_write_and_read_dir(real_store_path: PurePosixPath) -> None:
     """A store should be able to write and read the whole store."""
     store = Store.create(real_store_path, schema=CoolModel, primary_key="foo")
 
@@ -95,7 +95,7 @@ async def test_keyed_store_write_and_read_dir(real_store_path: PurePath) -> None
     assert ("oh", CoolModel(foo="oh", bar="hai")) in result
 
 
-async def test_keyed_store_write_and_ensure(real_store_path: PurePath) -> None:
+async def test_keyed_store_write_and_ensure(real_store_path: PurePosixPath) -> None:
     """A store should be able to write and read a file."""
     store = Store.create(real_store_path, schema=CoolModel, primary_key="foo")
     default_item = CoolModel(foo="some-key", bar="hello world")
@@ -110,7 +110,9 @@ async def test_keyed_store_write_and_ensure(real_store_path: PurePath) -> None:
     assert result == item
 
 
-async def test_store_write_and_read_with_migrations(real_store_path: PurePath) -> None:
+async def test_store_write_and_read_with_migrations(
+    real_store_path: PurePosixPath,
+) -> None:
     """A store should be able to write and read a file."""
     old_store = Store.create(real_store_path, schema=OldModel)
 
@@ -133,7 +135,7 @@ async def test_store_write_and_read_with_migrations(real_store_path: PurePath) -
     assert result == CoolModel(foo="hello", bar="world", baz=0)
 
 
-def test_store_sync_write_and_read(real_store_path: PurePath) -> None:
+def test_store_sync_write_and_read(real_store_path: PurePosixPath) -> None:
     """A store should be able to write and read a file synchronously."""
     store = Store.create(real_store_path, schema=CoolModel)
     item = CoolModel(foo="hello", bar="world")
@@ -147,7 +149,9 @@ def test_store_sync_write_and_read(real_store_path: PurePath) -> None:
     assert result == CoolModel(foo="hello", bar="world")
 
 
-async def test_store_write_and_read_with_nested_keys(real_store_path: PurePath) -> None:
+async def test_store_write_and_read_with_nested_keys(
+    real_store_path: PurePosixPath,
+) -> None:
     """A store should be able to write and read a file synchronously."""
     store = Store.create(real_store_path, schema=CoolModel)
     item = CoolModel(foo="hello", bar="world")

--- a/tests/test_read_store.py
+++ b/tests/test_read_store.py
@@ -1,6 +1,6 @@
 """Store tests for junk_drawer."""
 import pytest
-from pathlib import PurePath
+from pathlib import PurePosixPath
 from mock import AsyncMock  # type: ignore[attr-defined]
 
 from junk_drawer import ReadStore
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_store_exists_with_nonexistent_key(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should return False from store.exists if file doesn't exist."""
     mock_filesystem.file_exists.return_value = False
@@ -30,7 +30,7 @@ async def test_store_exists_with_nonexistent_key(
 
 
 def test_store_exists_sync_with_nonexistent_key(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should return False from store.exists if file doesn't exist."""
     mock_filesystem.sync.file_exists.return_value = False
@@ -61,7 +61,7 @@ def test_store_exists_sync_with_existing_key(
 
 
 async def test_store_get_with_nonexistent_key(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should return None from store.get if file doesn't exist."""
     mock_filesystem.read_json.side_effect = PathNotFoundError()
@@ -74,7 +74,7 @@ async def test_store_get_with_nonexistent_key(
 
 
 def test_store_get_sync_with_nonexistent_key(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should return None from store.get if file doesn't exist."""
     mock_filesystem.sync.read_json.side_effect = PathNotFoundError()
@@ -87,7 +87,7 @@ def test_store_get_sync_with_nonexistent_key(
 
 
 async def test_store_get_returns_read_result(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should return a model from store.get if file exists."""
     result = CoolModel(foo="bar", bar=42)
@@ -101,7 +101,7 @@ async def test_store_get_returns_read_result(
 
 
 def test_store_get_sync_returns_read_result(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should return a model from store.get if file exists."""
     result = CoolModel(foo="bar", bar=42)
@@ -115,7 +115,7 @@ def test_store_get_sync_returns_read_result(
 
 
 async def test_store_get_returns_read_result_from_deep_key(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should return a model from store.get if deep file exists."""
     result = CoolModel(foo="bar", bar=42)
@@ -129,7 +129,7 @@ async def test_store_get_returns_read_result_from_deep_key(
 
 
 def test_store_get_sync_returns_read_result_from_deep_key(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should return a model from store.get if deep file exists."""
     result = CoolModel(foo="bar", bar=42)
@@ -143,7 +143,7 @@ def test_store_get_sync_returns_read_result_from_deep_key(
 
 
 async def test_store_get_all_keys_reads_dir(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should read the directory and return all JSON files as keys."""
     mock_filesystem.read_dir.return_value = ["foo", "bar", "baz"]
@@ -154,7 +154,7 @@ async def test_store_get_all_keys_reads_dir(
 
 
 def test_store_get_all_keys_sync_reads_dir(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should read the directory and return all JSON files as keys."""
     mock_filesystem.sync.read_dir.return_value = ["foo", "bar", "baz"]
@@ -165,7 +165,7 @@ def test_store_get_all_keys_sync_reads_dir(
 
 
 async def test_store_get_all_entries_reads_dir(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should reads for all files in the directory to get all entries."""
     mock_filesystem.read_json_dir.return_value = [
@@ -184,7 +184,7 @@ async def test_store_get_all_entries_reads_dir(
 
 
 def test_store_get_all_entries_sync_reads_dir(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should reads for all files in the directory to get all entries."""
     mock_filesystem.sync.read_json_dir.return_value = [
@@ -203,7 +203,7 @@ def test_store_get_all_entries_sync_reads_dir(
 
 
 async def test_store_get_all_items_reads_dir(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should read all files in the directory to get all items."""
     mock_filesystem.read_json_dir.return_value = [
@@ -222,7 +222,7 @@ async def test_store_get_all_items_reads_dir(
 
 
 async def test_store_get_all_items_sync_reads_dir(
-    store: ReadStore[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: ReadStore[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """It should read all files in the directory to get all items."""
     mock_filesystem.sync.read_json_dir.return_value = [
@@ -286,7 +286,7 @@ async def test_store_get_raises_read_error(
 
 async def test_silenced_validation_error(
     ignore_errors_store: ReadStore[CoolModel],
-    store_path: PurePath,
+    store_path: PurePosixPath,
     mock_filesystem: AsyncMock,
 ) -> None:
     """It should return None in case of a validation error if set to not raise."""

--- a/tests/test_store_json_and_migrations.py
+++ b/tests/test_store_json_and_migrations.py
@@ -1,7 +1,7 @@
 """Tests for the store's JSON and migration handling."""
 import pytest
 from mock import AsyncMock  # type: ignore[attr-defined]
-from pathlib import PurePath
+from pathlib import PurePosixPath
 from pydantic import BaseModel
 from typing import Any, Dict
 
@@ -20,7 +20,7 @@ class StrictModel(CoolModel, BaseModel):
 
 @pytest.fixture
 def strict_store(
-    store_path: PurePath, mock_filesystem: AsyncMock
+    store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> Store[StrictModel]:
     """Create a Store with a strict model."""
     return Store(
@@ -35,7 +35,7 @@ def strict_store(
 
 @pytest.fixture
 def migrations_store(
-    store_path: PurePath, mock_filesystem: AsyncMock
+    store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> Store[CoolModel]:
     """Create a Store with migrations."""
 

--- a/tests/test_store_writes.py
+++ b/tests/test_store_writes.py
@@ -1,7 +1,7 @@
 """Store tests for junk_drawer."""
 import pytest
 from mock import AsyncMock  # type: ignore[attr-defined]
-from pathlib import PurePath
+from pathlib import PurePosixPath
 
 from junk_drawer import Store
 from junk_drawer.errors import ItemAccessError, ItemEncodeError
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_delete_store(
-    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.delete_store should remove the directory."""
     await store.delete_store()
@@ -26,7 +26,7 @@ async def test_delete_store(
 
 
 def test_delete_store_sync(
-    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.delete_store should remove the directory."""
     store.delete_store_sync()
@@ -34,7 +34,7 @@ def test_delete_store_sync(
 
 
 async def test_delete_item(
-    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.delete should remove a file."""
     key = "delete-me"
@@ -45,7 +45,7 @@ async def test_delete_item(
 
 
 async def test_delete_sync(
-    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.delete_sync should remove a file."""
     key = "delete-me"
@@ -100,7 +100,7 @@ def test_delete_sync_with_access_error(
 
 
 async def test_store_put(
-    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.put should call filesystem.write_json."""
     key = "cool-key"
@@ -116,7 +116,7 @@ async def test_store_put(
 
 
 def test_store_put_sync(
-    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.put should call filesystem.write_json."""
     key = "cool-key"
@@ -176,7 +176,7 @@ def test_store_put_sync_raises_encode_error(
 
 
 async def test_store_put_with_primary_key(
-    keyed_store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    keyed_store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.put should pull primary key from the model if available."""
     item = CoolModel(foo="hello", bar=0)
@@ -191,7 +191,7 @@ async def test_store_put_with_primary_key(
 
 
 def test_store_put_sync_with_primary_key(
-    keyed_store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    keyed_store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.put_sync should pull primary key from the model if available."""
     item = CoolModel(foo="hello", bar=0)
@@ -248,7 +248,7 @@ def test_store_put_sync_missing_key_asserts(
 
 
 async def test_store_put_bad_primary_key_asserts(
-    store_path: PurePath, mock_filesystem: AsyncMock
+    store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.put should assert if primary_key isn't in the model."""
     store = Store(
@@ -266,7 +266,7 @@ async def test_store_put_bad_primary_key_asserts(
 
 
 def test_store_put_sync_bad_primary_key_asserts(
-    store_path: PurePath, mock_filesystem: AsyncMock
+    store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.put_sync should assert if primary_key isn't in the model."""
     store = Store(
@@ -340,7 +340,7 @@ def test_store_ensure_sync(store: Store[CoolModel], mock_filesystem: AsyncMock) 
 
 
 async def test_store_ensure_writes_default(
-    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.ensure should write default item and return it."""
     default_item = CoolModel(foo="foo", bar=0)
@@ -357,7 +357,7 @@ async def test_store_ensure_writes_default(
 
 
 def test_store_ensure_sync_writes_default(
-    store: Store[CoolModel], store_path: PurePath, mock_filesystem: AsyncMock
+    store: Store[CoolModel], store_path: PurePosixPath, mock_filesystem: AsyncMock
 ) -> None:
     """store.ensure_sync should write default item and return it."""
     default_item = CoolModel(foo="foo", bar=0)


### PR DESCRIPTION
## overview

This PR makes a few changes to close #13

- Adds a `ReadStore` interface that can be used to create a read-only JSON store  
- Removes all side-effects (directory creation) from `Store.create`, instead deferring directory creation, if needed, to first document write
- Allows nested directory structure by recursing down the store directory and by interpreting `/`'s in item keys as directories
    - For full cross-platform support, all internal interfaces now use `PurePosixPath` rather than `PurePath`

## review requests

The guiding principle of this PR is the thought experiment: "what would it look like if we wanted to use a `Store` interface to access static JSON files like labware definitions and base pipette configurations?".

This PR is also making it pretty evident to me that there's a lot of redundant code coverage in this project, mostly left over from the creation of the `SyncFilesystem` class. I think a switch over to [decoy](https://github.com/mcous/decoy) from MagicMock will help revise some of the structure here